### PR TITLE
Adaptive time sync interval based on synchronization quality

### DIFF
--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -118,7 +118,7 @@ export class StateManager {
 
   clearTimeSyncInterval(): void {
     if (this.timeSyncInterval !== null) {
-      clearInterval(this.timeSyncInterval);
+      clearTimeout(this.timeSyncInterval);
       this.timeSyncInterval = null;
     }
   }


### PR DESCRIPTION
Replace fixed 5s time sync interval with dynamic intervals that match the Python client behavior. Syncs faster (200ms) when not yet synchronized or when error is high, and backs off to 5s when well-synchronized to reduce network overhead.

This is identical to the ESPHome and python client implementation, except that the interval for high accuracy is now 5s instead of 3s.