### PR TITLE
fix: remove verbose periodic and queue processing logs

### DIFF
--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -696,9 +696,6 @@ export class AudioProcessor {
       if (audioBuffer) {
         // Check if stream generation changed during async decode
         if (generation !== this.stateManager.streamGeneration) {
-          console.log(
-            "Sendspin: Discarding audio chunk from old stream (generation mismatch)",
-          );
           return;
         }
 
@@ -730,22 +727,15 @@ export class AudioProcessor {
 
     // Filter out any chunks from old streams (safety check)
     const currentGeneration = this.stateManager.streamGeneration;
-    this.audioBufferQueue = this.audioBufferQueue.filter((chunk) => {
-      if (chunk.generation !== currentGeneration) {
-        console.log(
-          "Sendspin: Filtering out audio chunk from old stream during queue processing",
-        );
-        return false;
-      }
-      return true;
-    });
+    this.audioBufferQueue = this.audioBufferQueue.filter(
+      (chunk) => chunk.generation === currentGeneration,
+    );
 
     // Sort queue by server timestamp to ensure proper ordering
     this.audioBufferQueue.sort((a, b) => a.serverTime - b.serverTime);
 
     // Don't schedule until time sync is ready
     if (!this.timeFilter.is_synchronized) {
-      console.log("Sendspin: Waiting for time sync before scheduling audio");
       return;
     }
 
@@ -854,7 +844,6 @@ export class AudioProcessor {
 
       // Drop chunks that arrived too late
       if (playbackTime < audioContextTime) {
-        console.log("Sendspin: Dropping late audio chunk");
         // Reset seamless tracking since we dropped a chunk
         this.nextPlaybackTime = 0;
         this.lastScheduledServerTime = 0;

--- a/src/protocol-handler.ts
+++ b/src/protocol-handler.ts
@@ -179,17 +179,6 @@ export class ProtocolHandler {
 
     // Update Kalman filter
     this.timeFilter.update(measurement, max_error, T4);
-
-    console.log(
-      "Sendspin: Clock sync - offset:",
-      (this.timeFilter.offset / 1000).toFixed(2),
-      "ms, outputLatency:",
-      (outputLatencyUs / 1000).toFixed(2),
-      "ms, error:",
-      (this.timeFilter.error / 1000).toFixed(2),
-      "ms, synced:",
-      this.timeFilter.is_synchronized,
-    );
   }
 
   // Handle stream start (also used for format updates per new spec)


### PR DESCRIPTION
Remove high-frequency console.log calls:
- Clock sync logging (every 200ms-5s)
- Audio chunk generation mismatch discards
- Queue processing filter logs
- Time sync wait logs
- Hard resync and gap detection logs
- Late chunk drop logs