### PR TITLE
Speed up changes to `setSyncDelay` by up to 10s

### DIFF
--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -66,6 +66,8 @@ export class AudioProcessor {
     // Reset seamless playback tracking to force resync with new delay
     this.nextPlaybackTime = 0;
     this.lastScheduledServerTime = 0;
+    // Reset EMA to prevent stale values from causing unnecessary corrections
+    this.smoothedSyncErrorMs = 0;
   }
 
   // Get current sync info for debugging/display


### PR DESCRIPTION
The smoothed EMA wasn't reset on calls to `setSyncDelay`, rendering the hard sync into a soft sync with a theoretical max delay of 10s. This PR fixes that.