### PR TITLE
Apply syncDelay at source.start() instead of target playback time

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,8 +229,8 @@
                 type="number"
                 id="sync-delay"
                 value="0"
-                min="-1000"
-                max="1000"
+                min="0"
+                max="5000"
                 step="10"
               />
               <button id="apply-sync-delay" class="btn btn-secondary">
@@ -238,7 +238,7 @@
               </button>
             </div>
             <small
-              >Adjust audio sync delay to compensate for device latency</small
+              >Adjust static delay to compensate for device latency (0-5000ms)</small
             >
           </div>
           <div class="form-group">

--- a/public/app.js
+++ b/public/app.js
@@ -427,7 +427,7 @@ function loadSettings() {
   // Load sync delay
   const savedSyncDelay = localStorage.getItem(STORAGE_KEYS.SYNC_DELAY);
   if (savedSyncDelay !== null) {
-    syncDelayInput.value = savedSyncDelay;
+    syncDelayInput.value = sanitizeSyncDelay(parseInt(savedSyncDelay, 10));
   }
 
   const savedCorrectionMode = localStorage.getItem(
@@ -457,6 +457,13 @@ function saveMuted(muted) {
  */
 function saveSyncDelay(delay) {
   localStorage.setItem(STORAGE_KEYS.SYNC_DELAY, delay.toString());
+}
+
+function sanitizeSyncDelay(delay) {
+  if (!Number.isFinite(delay)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(5000, Math.round(delay)));
 }
 
 /**
@@ -517,6 +524,7 @@ async function connect() {
       localStorage.getItem(STORAGE_KEYS.SYNC_DELAY) || "0",
       10,
     );
+    const sanitizedSyncDelay = sanitizeSyncDelay(savedSyncDelay);
     const savedCorrectionMode =
       localStorage.getItem(STORAGE_KEYS.CORRECTION_MODE) || "sync";
 
@@ -524,7 +532,7 @@ async function connect() {
       playerId: getPlayerId(),
       baseUrl: serverUrl,
       clientName: "Sendspin Sample Player",
-      syncDelay: savedSyncDelay,
+      syncDelay: sanitizedSyncDelay,
       correctionMode: savedCorrectionMode,
       onStateChange,
     });
@@ -636,7 +644,8 @@ function toggleMute() {
  * Apply sync delay
  */
 function applySyncDelay() {
-  const delay = parseInt(syncDelayInput.value, 10) || 0;
+  const delay = sanitizeSyncDelay(parseInt(syncDelayInput.value, 10));
+  syncDelayInput.value = delay;
   saveSyncDelay(delay);
   player.setSyncDelay(delay);
   showToast(`Sync delay set to ${delay}ms`, "success");

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -2074,6 +2074,8 @@ export class AudioProcessor {
         scheduleTime,
         audioContextRawTimeSec,
       );
+      const effectivePlaybackTime =
+        effectiveScheduleTime + (playbackTime - scheduleTime);
 
       const source = this.audioContext.createBufferSource();
       source.buffer = chunk.buffer;
@@ -2084,7 +2086,7 @@ export class AudioProcessor {
       // Track for seamless scheduling of next chunk
       // Account for actual duration with playback rate adjustment
       const actualDuration = chunk.buffer.duration / playbackRate;
-      this.nextPlaybackTime = playbackTime + actualDuration;
+      this.nextPlaybackTime = effectivePlaybackTime + actualDuration;
       this.nextScheduleTime = effectiveScheduleTime + actualDuration;
       this.lastScheduledServerTime =
         chunk.serverTime + chunk.buffer.duration * 1_000_000;

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -851,7 +851,6 @@ export class AudioProcessor {
       return;
     }
 
-    const syncDelaySec = this.syncDelayMs / 1000;
     const outputLatencySec = this.useOutputLatencyCompensation
       ? this.getSmoothedOutputLatencyUs() / 1_000_000
       : 0;
@@ -859,7 +858,6 @@ export class AudioProcessor {
       this.lastScheduledServerTime,
       audioContextTime,
       nowUs,
-      syncDelaySec,
       outputLatencySec,
     );
     const syncErrorMs = (this.nextPlaybackTime - targetPlaybackTime) * 1000;
@@ -1923,9 +1921,6 @@ export class AudioProcessor {
     } = this.getTimingSnapshot();
     this.pruneExpiredScheduledSources(audioContextRawTimeSec);
 
-    // Convert sync delay from ms to seconds (positive = play earlier)
-    const syncDelaySec = this.syncDelayMs / 1000;
-
     const outputLatencySec = this.useOutputLatencyCompensation
       ? this.getSmoothedOutputLatencyUs() / 1_000_000
       : 0;
@@ -1966,7 +1961,6 @@ export class AudioProcessor {
         chunk.serverTime,
         audioContextTime,
         nowUs,
-        syncDelaySec,
         outputLatencySec,
       );
 
@@ -2167,7 +2161,6 @@ export class AudioProcessor {
     serverTimeUs: number,
     audioContextTime: number,
     nowUs: number,
-    syncDelaySec: number,
     outputLatencySec: number,
   ): number {
     const chunkClientTimeUs = this.timeFilter.computeClientTime(serverTimeUs);
@@ -2177,7 +2170,6 @@ export class AudioProcessor {
       audioContextTime +
       deltaSec +
       SCHEDULE_HEADROOM_SEC -
-      syncDelaySec -
       outputLatencySec
     );
   }

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -2136,8 +2136,9 @@ export class AudioProcessor {
       // Track current rate for debugging
       this.currentPlaybackRate = playbackRate;
 
-      // Drop chunks that arrived too late
-      if (scheduleTime < audioContextRawTimeSec) {
+      // Drop only if we already missed the logical playback time. Missing the
+      // early-start window just means we apply less sync delay for this chunk.
+      if (playbackTime < audioContextRawTimeSec) {
         // Reset seamless tracking since we dropped a chunk
         this.nextPlaybackTime = 0;
         this.nextScheduleTime = 0;
@@ -2145,24 +2146,29 @@ export class AudioProcessor {
         continue;
       }
 
+      const effectiveScheduleTime = Math.max(
+        scheduleTime,
+        audioContextRawTimeSec,
+      );
+
       const source = this.audioContext.createBufferSource();
       source.buffer = chunk.buffer;
       source.playbackRate.value = playbackRate; // Apply rate correction
       source.connect(this.gainNode);
-      source.start(scheduleTime);
+      source.start(effectiveScheduleTime);
 
       // Track for seamless scheduling of next chunk
       // Account for actual duration with playback rate adjustment
       const actualDuration = chunk.buffer.duration / playbackRate;
       this.nextPlaybackTime = playbackTime + actualDuration;
-      this.nextScheduleTime = scheduleTime + actualDuration;
+      this.nextScheduleTime = effectiveScheduleTime + actualDuration;
       this.lastScheduledServerTime =
         chunk.serverTime + chunk.buffer.duration * 1_000_000;
 
       const scheduledEntry = {
         source,
-        startTime: scheduleTime,
-        endTime: scheduleTime + actualDuration,
+        startTime: effectiveScheduleTime,
+        endTime: effectiveScheduleTime + actualDuration,
         buffer: chunk.buffer,
         serverTime: chunk.serverTime,
         generation: chunk.generation,

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -1924,6 +1924,7 @@ export class AudioProcessor {
     const outputLatencySec = this.useOutputLatencyCompensation
       ? this.getSmoothedOutputLatencyUs() / 1_000_000
       : 0;
+    const syncDelaySec = this.syncDelayMs / 1000;
     const targetScheduledHorizonSec = this.getTargetScheduledHorizonSec();
     if (
       this._debugLogging &&
@@ -1954,6 +1955,7 @@ export class AudioProcessor {
       const chunk = this.audioBufferQueue.shift()!;
 
       let playbackTime: number;
+      let scheduleTime: number;
       let playbackRate: number;
 
       // Always compute the drift-corrected target time
@@ -1975,6 +1977,11 @@ export class AudioProcessor {
             ? Math.max(targetPlaybackTime, this.recorrectionMinStartTimeSec)
             : targetPlaybackTime;
         this.recorrectionMinStartTimeSec = null;
+        // Apply delay shift for scheduling; clamp to now during transients
+        scheduleTime = Math.max(
+          audioContextRawTimeSec,
+          playbackTime - syncDelaySec,
+        );
         playbackRate = 1.0;
         chunk.buffer = this.copyBuffer(chunk.buffer);
       } else {
@@ -2009,6 +2016,7 @@ export class AudioProcessor {
             // until the filter stabilizes (or timeout elapses)
             this.currentClockPrecision = "imprecise";
             playbackTime = this.nextPlaybackTime;
+            scheduleTime = this.nextScheduleTime;
             playbackRate = 1.0;
             this.currentCorrectionMethod = "none";
             this.lastSamplesAdjusted = 0;
@@ -2023,8 +2031,12 @@ export class AudioProcessor {
               // Tier 4: Hard resync if sync error exceeds threshold
               this.resyncCount++;
               this.resetSyncErrorEma();
-              this.cutScheduledSources(targetPlaybackTime);
+              this.cutScheduledSources(targetPlaybackTime - syncDelaySec);
               playbackTime = targetPlaybackTime;
+              scheduleTime = Math.max(
+                audioContextRawTimeSec,
+                playbackTime - syncDelaySec,
+              );
               playbackRate = 1.0;
               this.currentCorrectionMethod = "resync";
               this.lastSamplesAdjusted = 0;
@@ -2034,6 +2046,7 @@ export class AudioProcessor {
             ) {
               // Tier 1: Within deadband - no correction needed
               playbackTime = this.nextPlaybackTime;
+              scheduleTime = this.nextScheduleTime;
               playbackRate = 1.0;
               this.currentCorrectionMethod = "none";
               this.lastSamplesAdjusted = 0;
@@ -2043,6 +2056,7 @@ export class AudioProcessor {
             ) {
               // Tier 2: Small error - use single sample insertion/deletion
               playbackTime = this.nextPlaybackTime;
+              scheduleTime = this.nextScheduleTime;
               playbackRate = 1.0;
               const samplesToAdjust = correctionErrorMs > 0 ? -1 : 1;
               chunk.buffer = this.adjustBufferSamples(
@@ -2054,6 +2068,7 @@ export class AudioProcessor {
             } else {
               // Tier 3: Medium error - use playback rate adjustment
               playbackTime = this.nextPlaybackTime;
+              scheduleTime = this.nextScheduleTime;
               const absErrorMs = Math.abs(correctionErrorMs);
 
               if (correctionErrorMs > 0) {
@@ -2081,8 +2096,12 @@ export class AudioProcessor {
         } else {
           // Gap detected in server timestamps - hard resync
           this.resyncCount++;
-          this.cutScheduledSources(targetPlaybackTime);
+          this.cutScheduledSources(targetPlaybackTime - syncDelaySec);
           playbackTime = targetPlaybackTime;
+          scheduleTime = Math.max(
+            audioContextRawTimeSec,
+            playbackTime - syncDelaySec,
+          );
           playbackRate = 1.0;
           this.currentCorrectionMethod = "resync";
           this.lastSamplesAdjusted = 0;
@@ -2115,7 +2134,7 @@ export class AudioProcessor {
       this.currentPlaybackRate = playbackRate;
 
       // Drop chunks that arrived too late
-      if (playbackTime < audioContextRawTimeSec) {
+      if (scheduleTime < audioContextRawTimeSec) {
         // Reset seamless tracking since we dropped a chunk
         this.nextPlaybackTime = 0;
         this.lastScheduledServerTime = 0;
@@ -2126,19 +2145,20 @@ export class AudioProcessor {
       source.buffer = chunk.buffer;
       source.playbackRate.value = playbackRate; // Apply rate correction
       source.connect(this.gainNode);
-      source.start(playbackTime);
+      source.start(scheduleTime);
 
       // Track for seamless scheduling of next chunk
       // Account for actual duration with playback rate adjustment
       const actualDuration = chunk.buffer.duration / playbackRate;
       this.nextPlaybackTime = playbackTime + actualDuration;
+      this.nextScheduleTime = scheduleTime + actualDuration;
       this.lastScheduledServerTime =
         chunk.serverTime + chunk.buffer.duration * 1_000_000;
 
       const scheduledEntry = {
         source,
-        startTime: playbackTime,
-        endTime: playbackTime + actualDuration,
+        startTime: scheduleTime,
+        endTime: scheduleTime + actualDuration,
         buffer: chunk.buffer,
         serverTime: chunk.serverTime,
         generation: chunk.generation,
@@ -2167,10 +2187,7 @@ export class AudioProcessor {
     const deltaUs = chunkClientTimeUs - nowUs;
     const deltaSec = deltaUs / 1_000_000;
     return (
-      audioContextTime +
-      deltaSec +
-      SCHEDULE_HEADROOM_SEC -
-      outputLatencySec
+      audioContextTime + deltaSec + SCHEDULE_HEADROOM_SEC - outputLatencySec
     );
   }
 

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -331,7 +331,7 @@ export class AudioProcessor {
   }
 
   private getScheduledAheadSec(currentTimeSec: number): number {
-    let farthestScheduledSec = this.nextPlaybackTime;
+    let farthestScheduledSec = this.nextScheduleTime;
     for (const entry of this.scheduledSources) {
       if (entry.endTime > farthestScheduledSec) {
         farthestScheduledSec = entry.endTime;

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -2137,6 +2137,7 @@ export class AudioProcessor {
       if (scheduleTime < audioContextRawTimeSec) {
         // Reset seamless tracking since we dropped a chunk
         this.nextPlaybackTime = 0;
+        this.nextScheduleTime = 0;
         this.lastScheduledServerTime = 0;
         continue;
       }

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -158,7 +158,8 @@ export class AudioProcessor {
   }[] = [];
 
   // Seamless playback tracking
-  private nextPlaybackTime: number = 0; // AudioContext time when next chunk should start
+  private nextPlaybackTime: number = 0; // AudioContext time when next chunk should start (non-delayed, for correction)
+  private nextScheduleTime: number = 0; // AudioContext time for source.start() (delayed, for Web Audio)
   private lastScheduledServerTime: number = 0; // Server timestamp of last scheduled chunk end
 
   // Sync tracking (for debugging/display)
@@ -651,6 +652,7 @@ export class AudioProcessor {
       this.scheduledSources.length > 0;
 
     this.nextPlaybackTime = 0;
+    this.nextScheduleTime = 0;
     this.lastScheduledServerTime = 0;
     this.recorrectionMinStartTimeSec = null;
     this.resetRecorrectionCheckState();
@@ -791,6 +793,7 @@ export class AudioProcessor {
       cutResult.keptTailEndTimeSec,
     );
     this.nextPlaybackTime = 0;
+    this.nextScheduleTime = 0;
     this.lastScheduledServerTime = 0;
     this.resetRecorrectionCheckState();
     if (markCooldown) {

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -158,7 +158,7 @@ export class AudioProcessor {
   }[] = [];
 
   // Seamless playback tracking
-  private nextPlaybackTime: number = 0; // AudioContext time when next chunk should start (non-delayed, for correction)
+  private nextPlaybackTime: number = 0; // AudioContext time when audio should reach the output
   private nextScheduleTime: number = 0; // AudioContext time for source.start() (delayed, for Web Audio)
   private lastScheduledServerTime: number = 0; // Server timestamp of last scheduled chunk end
 
@@ -207,7 +207,7 @@ export class AudioProcessor {
   private recorrectionInterval: ReturnType<typeof setInterval> | null = null;
   private recorrectionBreachStartedAtMs: number | null = null;
   private lastRecorrectionAtMs: number = -Infinity;
-  private recorrectionMinStartTimeSec: number | null = null;
+  private recorrectionMinScheduleTimeSec: number | null = null;
   private recorrectionPrevRawSyncErrorMs: number | null = null;
   private recorrectionPendingJumpSign: number | null = null;
   private recorrectionPendingJumpAtMs: number | null = null;
@@ -234,9 +234,17 @@ export class AudioProcessor {
   ) {
     this._correctionMode = correctionMode;
     this.useOutputLatencyCompensation = useOutputLatencyCompensation;
+    this.syncDelayMs = this.sanitizeSyncDelayMs(this.syncDelayMs);
 
     // Load persisted output latency from storage
     this.loadPersistedLatency();
+  }
+
+  private sanitizeSyncDelayMs(delayMs: number): number {
+    if (!isFinite(delayMs)) {
+      return 0;
+    }
+    return Math.max(0, Math.min(5000, Math.round(delayMs)));
   }
 
   // Load persisted output latency from storage
@@ -654,7 +662,7 @@ export class AudioProcessor {
     this.nextPlaybackTime = 0;
     this.nextScheduleTime = 0;
     this.lastScheduledServerTime = 0;
-    this.recorrectionMinStartTimeSec = null;
+    this.recorrectionMinScheduleTimeSec = null;
     this.resetRecorrectionCheckState();
     this.resetSyncErrorEma();
     this.currentSyncErrorMs = 0;
@@ -788,7 +796,7 @@ export class AudioProcessor {
     this.lastSamplesAdjusted = 0;
     this.currentPlaybackRate = 1.0;
     const cutResult = this.cutScheduledSources(cutoffTime);
-    this.recorrectionMinStartTimeSec = Math.max(
+    this.recorrectionMinScheduleTimeSec = Math.max(
       cutoffTime,
       cutResult.keptTailEndTimeSec,
     );
@@ -809,7 +817,7 @@ export class AudioProcessor {
         `Sendspin: [sync] ${label} at t+${(
           RECORRECTION_CUTOVER_GUARD_SEC * 1000
         ).toFixed(0)}ms ` +
-          `| minStart=${(this.recorrectionMinStartTimeSec - this.audioContext.currentTime).toFixed(3)}s ` +
+          `| minStart=${(this.recorrectionMinScheduleTimeSec - this.audioContext.currentTime).toFixed(3)}s ` +
           `| requeued=${cutResult.requeuedCount} cut=${cutResult.cutCount} queue=${this.audioBufferQueue.length} scheduled=${this.scheduledSources.length}`,
       );
     }
@@ -917,9 +925,10 @@ export class AudioProcessor {
 
   // Update sync delay at runtime
   setSyncDelay(delayMs: number): void {
+    const sanitizedDelayMs = this.sanitizeSyncDelayMs(delayMs);
     const oldDelayMs = this.syncDelayMs;
-    const deltaMs = delayMs - oldDelayMs;
-    this.syncDelayMs = delayMs;
+    const deltaMs = sanitizedDelayMs - oldDelayMs;
+    this.syncDelayMs = sanitizedDelayMs;
 
     if (this._debugLogging) {
       const scheduledAheadSec =
@@ -927,7 +936,7 @@ export class AudioProcessor {
           ? this.getScheduledAheadSec(this.audioContext.currentTime)
           : 0;
       console.log(
-        `Sendspin: Sync delay changed ${oldDelayMs}ms -> ${delayMs}ms (delta=${deltaMs}ms) ` +
+        `Sendspin: Sync delay changed ${oldDelayMs}ms -> ${sanitizedDelayMs}ms (delta=${deltaMs}ms) ` +
           `| scheduledAhead=${scheduledAheadSec.toFixed(3)}s queue=${this.audioBufferQueue.length} scheduled=${this.scheduledSources.length}`,
       );
     }
@@ -1972,16 +1981,16 @@ export class AudioProcessor {
         if (this.playbackStartedAt === null) {
           this.playbackStartedAt = performance.now();
         }
-        playbackTime =
-          this.recorrectionMinStartTimeSec !== null
-            ? Math.max(targetPlaybackTime, this.recorrectionMinStartTimeSec)
-            : targetPlaybackTime;
-        this.recorrectionMinStartTimeSec = null;
-        // Apply delay shift for scheduling; clamp to now during transients
-        scheduleTime = Math.max(
-          audioContextRawTimeSec,
-          playbackTime - syncDelaySec,
-        );
+        playbackTime = targetPlaybackTime;
+        scheduleTime = playbackTime - syncDelaySec;
+        if (this.recorrectionMinScheduleTimeSec !== null) {
+          scheduleTime = Math.max(
+            scheduleTime,
+            this.recorrectionMinScheduleTimeSec,
+          );
+          playbackTime = scheduleTime + syncDelaySec;
+        }
+        this.recorrectionMinScheduleTimeSec = null;
         playbackRate = 1.0;
         chunk.buffer = this.copyBuffer(chunk.buffer);
       } else {
@@ -2033,10 +2042,7 @@ export class AudioProcessor {
               this.resetSyncErrorEma();
               this.cutScheduledSources(targetPlaybackTime - syncDelaySec);
               playbackTime = targetPlaybackTime;
-              scheduleTime = Math.max(
-                audioContextRawTimeSec,
-                playbackTime - syncDelaySec,
-              );
+              scheduleTime = playbackTime - syncDelaySec;
               playbackRate = 1.0;
               this.currentCorrectionMethod = "resync";
               this.lastSamplesAdjusted = 0;
@@ -2098,10 +2104,7 @@ export class AudioProcessor {
           this.resyncCount++;
           this.cutScheduledSources(targetPlaybackTime - syncDelaySec);
           playbackTime = targetPlaybackTime;
-          scheduleTime = Math.max(
-            audioContextRawTimeSec,
-            playbackTime - syncDelaySec,
-          );
+          scheduleTime = playbackTime - syncDelaySec;
           playbackRate = 1.0;
           this.currentCorrectionMethod = "resync";
           this.lastSamplesAdjusted = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,16 +51,16 @@ function detectIsWindows(): boolean {
 }
 
 /**
- * Get platform-specific default sync delay in milliseconds.
+ * Get platform-specific default static delay in milliseconds.
  * Based on testing across various platforms and browsers.
  */
 function getDefaultSyncDelay(): number {
-  if (detectIsIOS()) return -250;
-  if (detectIsAndroid()) return -200;
-  if (detectIsMac()) return detectIsSafari() ? -190 : -150;
-  if (detectIsWindows()) return -250;
+  if (detectIsIOS()) return 250;
+  if (detectIsAndroid()) return 200;
+  if (detectIsMac()) return detectIsSafari() ? 190 : 150;
+  if (detectIsWindows()) return 250;
   // Linux and others
-  return -200;
+  return 200;
 }
 
 function generateRandomId(): string {
@@ -245,7 +245,7 @@ export class SendspinPlayer {
     this.protocolHandler.sendStateUpdate();
   }
 
-  // Set sync delay (in milliseconds). Runtime behavior depends on correction mode settings.
+  // Set static delay (in milliseconds, 0-5000). Positive values schedule playback earlier.
   setSyncDelay(delayMs: number): void {
     this.audioProcessor.setSyncDelay(delayMs);
     this.protocolHandler.sendStateUpdate();

--- a/src/types.ts
+++ b/src/types.ts
@@ -306,10 +306,10 @@ export interface SendspinPlayerConfig {
 
   /**
    * Static sync delay in milliseconds.
-   * Positive values make playback earlier, negative values delay it.
-   * Use this to compensate for device-specific audio latency.
+   * Positive values make playback earlier to compensate for downstream device latency.
+   * Allowed range: 0-5000.
    * Runtime update behavior depends on the active correction mode settings.
-   * Defaults to a platform-specific value if not provided (see `getDefaultSyncDelay()`).
+   * Defaults to a browser/platform-specific heuristic value if not provided.
    */
   syncDelay?: number;
 
@@ -368,8 +368,7 @@ export interface SendspinPlayerConfig {
 
   /**
    * Callback when server sends a set_static_delay command.
-   * Called with the new delay in milliseconds (0-5000, protocol convention:
-   * positive = play earlier to compensate for device latency).
+   * Called with the new static delay in milliseconds (0-5000).
    */
   onDelayCommand?: (delayMs: number) => void;
 


### PR DESCRIPTION
Follow-up to #66.

## Summary

- Separate `nextPlaybackTime` (when audio should reach the listener) from `nextScheduleTime` (when `source.start()` fires), applying `syncDelay` only at the scheduling layer
- `computeTargetPlaybackTime` no longer includes syncDelay — sync error calculations are now against the true target time
- Clamp late-arriving chunks to "now" instead of dropping when only the early-start window was missed
- Sanitize `syncDelay` input to 0–5000 range
- Update docs and comments to use "static delay" terminology

## Breaking changes

Sign convention flipped: `syncDelay` is now positive (0–5000). Old negative defaults (-250, -200, etc.) are replaced with positive equivalents. Negative values are clamped to 0.