### PR TITLE
Improve debug logging with periodic status updates

### DIFF
--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -211,7 +211,6 @@ export class AudioProcessor {
   private recorrectionPrevRawSyncErrorMs: number | null = null;
   private recorrectionPendingJumpSign: number | null = null;
   private recorrectionPendingJumpAtMs: number | null = null;
-  private lastLoggedHorizonSec: number | null = null;
   private activeAudioClockSource: AudioClockSource = "estimated";
   private outputTimestampLastSample: OutputTimestampSample | null = null;
   private outputTimestampGoodSamples: number = 0;
@@ -248,11 +247,6 @@ export class AudioProcessor {
         const latency = parseFloat(stored);
         if (!isNaN(latency) && latency >= 0) {
           this.smoothedOutputLatencyUs = latency;
-          if (this._debugLogging) {
-            console.log(
-              `Sendspin: Loaded persisted output latency: ${(latency / 1000).toFixed(1)}ms`,
-            );
-          }
         }
       }
     } catch {
@@ -288,23 +282,6 @@ export class AudioProcessor {
     } else {
       this.startRecorrectionMonitor();
     }
-    if (this._debugLogging) {
-      console.log(
-        `Sendspin: Correction mode changed: '${oldMode}' -> '${mode}' ` +
-          `(resyncAboveMs=${thresholds.resyncAboveMs}ms, rate2AboveMs=${thresholds.rate2AboveMs}ms, rate1AboveMs=${thresholds.rate1AboveMs}ms, ` +
-          `samplesBelowMs=${thresholds.samplesBelowMs}ms, deadbandBelowMs=${thresholds.deadbandBelowMs}ms)`,
-      );
-    }
-  }
-
-  // Enable/disable debug logging for sync corrections
-  setDebugLogging(enabled: boolean): void {
-    this._debugLogging = enabled;
-  }
-
-  // Get debug logging state
-  get debugLogging(): boolean {
-    return this._debugLogging;
   }
 
   private modeUsesRecorrectionMonitor(mode: CorrectionMode): boolean {
@@ -343,21 +320,11 @@ export class AudioProcessor {
     return Math.max(0, farthestScheduledSec - currentTimeSec);
   }
 
-  private setActiveAudioClockSource(
-    source: AudioClockSource,
-    reason: string,
-  ): void {
+  private setActiveAudioClockSource(source: AudioClockSource): void {
     if (this.activeAudioClockSource === source) {
       return;
     }
-
-    const previousSource = this.activeAudioClockSource;
     this.activeAudioClockSource = source;
-    if (this._debugLogging) {
-      console.log(
-        `Sendspin: Audio clock source ${previousSource} -> ${source} (${reason})`,
-      );
-    }
   }
 
   private resetOutputTimestampValidation(): void {
@@ -579,10 +546,7 @@ export class AudioProcessor {
         nowMs - this.outputTimestampGoodSinceMs >=
           OUTPUT_TIMESTAMP_PROMOTION_MIN_SPAN_MS
       ) {
-        this.setActiveAudioClockSource(
-          "timestamp",
-          `validated ${this.outputTimestampGoodSamples} samples over ${(nowMs - this.outputTimestampGoodSinceMs).toFixed(0)}ms`,
-        );
+        this.setActiveAudioClockSource("timestamp");
         this._lastTimestampRejectReason = null;
       }
 
@@ -640,14 +604,7 @@ export class AudioProcessor {
     };
   }
 
-  private resetScheduledPlaybackState(reason?: string): void {
-    const hadScheduledState =
-      this.nextPlaybackTime !== 0 ||
-      this.lastScheduledServerTime !== 0 ||
-      this.currentSyncErrorMs !== 0 ||
-      this.currentCorrectionMethod !== "none" ||
-      this.scheduledSources.length > 0;
-
+  private resetScheduledPlaybackState(_reason?: string): void {
     this.nextPlaybackTime = 0;
     this.lastScheduledServerTime = 0;
     this.recorrectionMinStartTimeSec = null;
@@ -659,26 +616,16 @@ export class AudioProcessor {
     this.lastSamplesAdjusted = 0;
     this.playbackStartedAt = null;
     this.currentClockPrecision = "imprecise";
-
-    if (reason && hadScheduledState && this._debugLogging) {
-      console.log(`Sendspin: Reset scheduled playback state (${reason})`);
-    }
   }
 
   private pruneExpiredScheduledSources(currentTimeSec: number): void {
-    const before = this.scheduledSources.length;
-    if (before === 0) {
+    if (this.scheduledSources.length === 0) {
       return;
     }
 
     this.scheduledSources = this.scheduledSources.filter(
       (entry) => entry.endTime > currentTimeSec,
     );
-
-    const pruned = before - this.scheduledSources.length;
-    if (pruned > 0 && this._debugLogging) {
-      console.log(`Sendspin: Pruned ${pruned} expired scheduled chunk(s)`);
-    }
 
     if (this.scheduledSources.length === 0) {
       this.resetScheduledPlaybackState("no scheduled audio ahead");
@@ -688,9 +635,6 @@ export class AudioProcessor {
   private startRecorrectionMonitor(): void {
     if (this.recorrectionInterval !== null) {
       return;
-    }
-    if (this._debugLogging) {
-      console.log("Sendspin: [sync] Recorrection monitor started (250ms)");
     }
     this.recorrectionInterval = globalThis.setInterval(
       () => this.checkRecorrection(),
@@ -702,9 +646,6 @@ export class AudioProcessor {
     if (this.recorrectionInterval !== null) {
       clearInterval(this.recorrectionInterval);
       this.recorrectionInterval = null;
-      if (this._debugLogging) {
-        console.log("Sendspin: [sync] Recorrection monitor stopped");
-      }
     }
     this.resetRecorrectionCheckState();
     this.lastRecorrectionAtMs = -Infinity;
@@ -796,20 +737,6 @@ export class AudioProcessor {
       this.lastRecorrectionAtMs = nowMs;
     }
 
-    if (this._debugLogging) {
-      const label =
-        reason === "recorrection"
-          ? "Recorrection cutover"
-          : "Delay-change cutover";
-      console.log(
-        `Sendspin: [sync] ${label} at t+${(
-          RECORRECTION_CUTOVER_GUARD_SEC * 1000
-        ).toFixed(0)}ms ` +
-          `| minStart=${(this.recorrectionMinStartTimeSec - this.audioContext.currentTime).toFixed(3)}s ` +
-          `| requeued=${cutResult.requeuedCount} cut=${cutResult.cutCount} queue=${this.audioBufferQueue.length} scheduled=${this.scheduledSources.length}`,
-      );
-    }
-
     this.processAudioQueue();
   }
 
@@ -871,20 +798,10 @@ export class AudioProcessor {
     }
     if (isTransientJump) {
       this.clearRecorrectionBreachState();
-      if (this._debugLogging) {
-        console.log(
-          `Sendspin: [sync] Recorrection transient jump ignored: rawError=${syncErrorMs.toFixed(1)}ms`,
-        );
-      }
       return;
     }
     if (this.recorrectionBreachStartedAtMs === null) {
       this.recorrectionBreachStartedAtMs = nowMs;
-      if (this._debugLogging) {
-        console.log(
-          `Sendspin: [sync] Recorrection breach started: error=${absErrorMs.toFixed(1)}ms`,
-        );
-      }
       return;
     }
     if (nowMs - this.recorrectionBreachStartedAtMs < RECORRECTION_SUSTAIN_MS) {
@@ -894,11 +811,6 @@ export class AudioProcessor {
       return;
     }
 
-    if (this._debugLogging) {
-      console.log(
-        `Sendspin: [sync] Recorrection trigger: error=${absErrorMs.toFixed(1)}ms sustained=${(nowMs - this.recorrectionBreachStartedAtMs).toFixed(0)}ms scheduledAhead=${scheduledAheadSec.toFixed(3)}s`,
-      );
-    }
     this.applyRecorrectionCutover();
   }
 
@@ -918,17 +830,6 @@ export class AudioProcessor {
     const oldDelayMs = this.syncDelayMs;
     const deltaMs = delayMs - oldDelayMs;
     this.syncDelayMs = delayMs;
-
-    if (this._debugLogging) {
-      const scheduledAheadSec =
-        this.audioContext && this.audioContext.state === "running"
-          ? this.getScheduledAheadSec(this.audioContext.currentTime)
-          : 0;
-      console.log(
-        `Sendspin: Sync delay changed ${oldDelayMs}ms -> ${delayMs}ms (delta=${deltaMs}ms) ` +
-          `| scheduledAhead=${scheduledAheadSec.toFixed(3)}s queue=${this.audioBufferQueue.length} scheduled=${this.scheduledSources.length}`,
-      );
-    }
 
     if (deltaMs === 0 || !this.usesImmediateDelayCutover) {
       return;
@@ -998,7 +899,8 @@ export class AudioProcessor {
     }
 
     // q field
-    const queueDepth = this.audioBufferQueue.length + this.scheduledSources.length;
+    const queueDepth =
+      this.audioBufferQueue.length + this.scheduledSources.length;
     const aheadSec = this.audioContext
       ? this.getScheduledAheadSec(this.audioContext.currentTime)
       : 0;
@@ -1019,9 +921,10 @@ export class AudioProcessor {
       : `pending(n=${this.timeFilter.count})`;
 
     // lat field
-    const latMs = this.smoothedOutputLatencyUs !== null
-      ? Math.round(this.smoothedOutputLatencyUs / 1000)
-      : 0;
+    const latMs =
+      this.smoothedOutputLatencyUs !== null
+        ? Math.round(this.smoothedOutputLatencyUs / 1000)
+        : 0;
 
     console.log(
       `Sendspin: sync=${this.smoothedSyncErrorMs >= 0 ? "+" : ""}${this.smoothedSyncErrorMs.toFixed(1)}ms` +
@@ -1087,11 +990,6 @@ export class AudioProcessor {
     ) {
       this.persistLatency();
       this.lastLatencyPersistAtMs = nowMs;
-      if (this._debugLogging) {
-        console.debug(
-          `Sendspin: Persisted smoothed output latency: ${this.smoothedOutputLatencyUs} µs`,
-        );
-      }
     }
 
     return this.smoothedOutputLatencyUs;
@@ -1333,11 +1231,6 @@ export class AudioProcessor {
       cutCount++;
       return false;
     });
-    if (this._debugLogging && requeued > 0) {
-      console.log(
-        `Sendspin: Requeued ${requeued} future chunk(s) after cutover`,
-      );
-    }
     return {
       requeuedCount: requeued,
       cutCount,
@@ -1517,22 +1410,12 @@ export class AudioProcessor {
       const metadata = this.nativeDecoderQueue.shift();
 
       if (!metadata) {
-        if (this._debugLogging) {
-          console.debug(
-            `[NativeOpus] Dropping frame with empty decode queue (out ts=${outputTimestampUs})`,
-          );
-        }
         audioData.close();
         return;
       }
 
       const { serverTimeUs, generation } = metadata;
       if (generation !== this.stateManager.streamGeneration) {
-        if (this._debugLogging) {
-          console.debug(
-            `[NativeOpus] Dropping old-stream frame (ts=${serverTimeUs}, gen=${generation} != current=${this.stateManager.streamGeneration})`,
-          );
-        }
         audioData.close();
         return;
       }
@@ -1988,15 +1871,6 @@ export class AudioProcessor {
       ? this.getSmoothedOutputLatencyUs() / 1_000_000
       : 0;
     const targetScheduledHorizonSec = this.getTargetScheduledHorizonSec();
-    if (
-      this._debugLogging &&
-      this.lastLoggedHorizonSec !== targetScheduledHorizonSec
-    ) {
-      console.log(
-        `Sendspin: Scheduling horizon -> ${targetScheduledHorizonSec.toFixed(0)}s (timeFilterError=${(this.timeFilter.error / 1000).toFixed(2)}ms)`,
-      );
-      this.lastLoggedHorizonSec = targetScheduledHorizonSec;
-    }
 
     if (this.usesRecorrectionMonitor) {
       this.startRecorrectionMonitor();
@@ -2153,27 +2027,6 @@ export class AudioProcessor {
           this.currentCorrectionMethod = "resync";
           this.lastSamplesAdjusted = 0;
           chunk.buffer = this.copyBuffer(chunk.buffer);
-        }
-      }
-
-      // Debug logging when correction method changes
-      if (this._debugLogging) {
-        if (this.currentCorrectionMethod !== this._lastLoggedCorrectionMethod) {
-          const thresholds = CORRECTION_THRESHOLDS[this._correctionMode];
-          console.log(
-            `Sendspin: [${this._correctionMode}] Correction: ${this._lastLoggedCorrectionMethod} -> ${this.currentCorrectionMethod} ` +
-              `| syncError=${this.smoothedSyncErrorMs.toFixed(1)}ms ` +
-              `| rate=${playbackRate} | resyncs=${this.resyncCount} | filterError=${this.timeFilter.error}` +
-              `| thresholds: resync>${thresholds.resyncAboveMs}ms, samples<${thresholds.samplesBelowMs}ms, rate1>=${thresholds.rate1AboveMs}ms, rate2>=${thresholds.rate2AboveMs}ms`,
-          );
-          this._lastLoggedCorrectionMethod = this.currentCorrectionMethod;
-          this._lastLoggedTime = performance.now();
-        } else if (performance.now() - this._lastLoggedTime > 2000) {
-          console.log(
-            `Sendspin: syncError=${this.smoothedSyncErrorMs.toFixed(1)}ms ` +
-              `| filterError=${this.timeFilter.error}`,
-          );
-          this._lastLoggedTime = performance.now();
         }
       }
 

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -182,10 +182,11 @@ export class AudioProcessor {
 
   // Correction mode
   private _correctionMode: CorrectionMode = "sync";
-  private _debugLogging: boolean = false;
-  private _lastLoggedCorrectionMethod: "none" | "samples" | "rate" | "resync" =
-    "none";
-  private _lastLoggedTime: number = 0;
+
+  // Periodic status logging
+  private _lastStatusLogMs: number = 0;
+  private _lastTimestampRejectReason: string | null = null;
+  private _intervalResyncCount: number = 0;
 
   // Native Opus decoder (uses WebCodecs API)
   private webCodecsDecoder: AudioDecoder | null = null;

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -274,9 +274,7 @@ export class AudioProcessor {
 
   // Set correction mode at runtime
   setCorrectionMode(mode: CorrectionMode): void {
-    const oldMode = this._correctionMode;
     this._correctionMode = mode;
-    const thresholds = CORRECTION_THRESHOLDS[mode];
     if (!this.modeUsesRecorrectionMonitor(mode)) {
       this.stopRecorrectionMonitor();
     } else {

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -978,6 +978,67 @@ export class AudioProcessor {
     };
   }
 
+  private emitStatusLog(nowMs: number): void {
+    if (nowMs - this._lastStatusLogMs < 10_000) {
+      return;
+    }
+    this._lastStatusLogMs = nowMs;
+
+    // corr field
+    let corr: string;
+    switch (this.currentCorrectionMethod) {
+      case "rate":
+        corr = `rate@${this.currentPlaybackRate}`;
+        break;
+      case "samples":
+        corr = `samples:${this.lastSamplesAdjusted}`;
+        break;
+      default:
+        corr = this.currentCorrectionMethod;
+    }
+
+    // q field
+    const queueDepth = this.audioBufferQueue.length + this.scheduledSources.length;
+    const aheadSec = this.audioContext
+      ? this.getScheduledAheadSec(this.audioContext.currentTime)
+      : 0;
+
+    // clock field
+    let clock: string;
+    if (this.activeAudioClockSource === "timestamp") {
+      clock = `timestamp(good:${this.outputTimestampGoodSamples})`;
+    } else if (this._lastTimestampRejectReason) {
+      clock = `estimated(reject:"${this._lastTimestampRejectReason}")`;
+    } else {
+      clock = "estimated";
+    }
+
+    // tf field
+    const tf = this.timeFilter.is_synchronized
+      ? `synced(err=${(this.timeFilter.error / 1000).toFixed(1)}ms,drift=${this.timeFilter.drift.toFixed(3)},n=${this.timeFilter.count})`
+      : `pending(n=${this.timeFilter.count})`;
+
+    // lat field
+    const latMs = this.smoothedOutputLatencyUs !== null
+      ? Math.round(this.smoothedOutputLatencyUs / 1000)
+      : 0;
+
+    console.log(
+      `Sendspin: sync=${this.smoothedSyncErrorMs >= 0 ? "+" : ""}${this.smoothedSyncErrorMs.toFixed(1)}ms` +
+        ` corr=${corr}` +
+        ` q=${queueDepth}/${aheadSec.toFixed(1)}s` +
+        ` resyncs=${this._intervalResyncCount}` +
+        ` clock=${clock}` +
+        ` tf=${tf}` +
+        ` lat=${latMs}ms` +
+        ` prec=${this.currentClockPrecision}` +
+        ` ctx=${this.audioContext?.state ?? "null"}` +
+        ` gen=${this.stateManager.streamGeneration}`,
+    );
+
+    this._intervalResyncCount = 0;
+  }
+
   private applySyncErrorEma(inputMs: number): number {
     this.currentSyncErrorMs = inputMs;
     this.smoothedSyncErrorMs =
@@ -1915,6 +1976,7 @@ export class AudioProcessor {
     const {
       audioContextTimeSec: audioContextTime,
       audioContextRawTimeSec,
+      nowMs,
       nowUs,
     } = this.getTimingSnapshot();
     this.pruneExpiredScheduledSources(audioContextRawTimeSec);
@@ -2159,6 +2221,7 @@ export class AudioProcessor {
         }
       };
     }
+    this.emitStatusLog(nowMs);
   }
 
   private computeTargetPlaybackTime(

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -329,6 +329,7 @@ export class AudioProcessor {
     this.activeAudioClockSource = "estimated";
     this.outputTimestampLastSample = null;
     this.outputTimestampGoodSamples = 0;
+    this._lastTimestampRejectReason = null;
     this.outputTimestampBadSamples = 0;
     this.outputTimestampGoodSinceMs = null;
   }
@@ -614,6 +615,8 @@ export class AudioProcessor {
     this.lastSamplesAdjusted = 0;
     this.playbackStartedAt = null;
     this.currentClockPrecision = "imprecise";
+    this._lastStatusLogMs = 0;
+    this._intervalResyncCount = 0;
   }
 
   private pruneExpiredScheduledSources(currentTimeSec: number): void {
@@ -878,7 +881,7 @@ export class AudioProcessor {
   }
 
   private emitStatusLog(nowMs: number): void {
-    if (nowMs - this._lastStatusLogMs < 10_000) {
+    if (this._lastStatusLogMs !== 0 && nowMs - this._lastStatusLogMs < 10_000) {
       return;
     }
     this._lastStatusLogMs = nowMs;

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -778,6 +778,7 @@ export class AudioProcessor {
       this.audioContext.currentTime + RECORRECTION_CUTOVER_GUARD_SEC;
     if (incrementResyncCount) {
       this.resyncCount++;
+      this._intervalResyncCount++;
     }
     this.resetSyncErrorEma();
     this.currentCorrectionMethod = "resync";
@@ -2023,6 +2024,7 @@ export class AudioProcessor {
             if (Math.abs(correctionErrorMs) > thresholds.resyncAboveMs) {
               // Tier 4: Hard resync if sync error exceeds threshold
               this.resyncCount++;
+              this._intervalResyncCount++;
               this.resetSyncErrorEma();
               this.cutScheduledSources(targetPlaybackTime);
               playbackTime = targetPlaybackTime;
@@ -2082,6 +2084,7 @@ export class AudioProcessor {
         } else {
           // Gap detected in server timestamps - hard resync
           this.resyncCount++;
+          this._intervalResyncCount++;
           this.cutScheduledSources(targetPlaybackTime);
           playbackTime = targetPlaybackTime;
           playbackRate = 1.0;

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -932,6 +932,7 @@ export class AudioProcessor {
         ` clock=${clock}` +
         ` tf=${tf}` +
         ` lat=${latMs}ms` +
+        ` mode=${this._correctionMode}` +
         ` prec=${this.currentClockPrecision}` +
         ` ctx=${this.audioContext?.state ?? "null"}` +
         ` gen=${this.stateManager.streamGeneration}`,
@@ -1408,12 +1409,18 @@ export class AudioProcessor {
       const metadata = this.nativeDecoderQueue.shift();
 
       if (!metadata) {
+        console.warn(
+          `[NativeOpus] Dropping frame with empty decode queue (out ts=${outputTimestampUs})`,
+        );
         audioData.close();
         return;
       }
 
       const { serverTimeUs, generation } = metadata;
       if (generation !== this.stateManager.streamGeneration) {
+        console.warn(
+          `[NativeOpus] Dropping old-stream frame (ts=${serverTimeUs}, gen=${generation} != current=${this.stateManager.streamGeneration})`,
+        );
         audioData.close();
         return;
       }

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -369,13 +369,8 @@ export class AudioProcessor {
   }
 
   private demoteOutputTimestampValidation(reason: string): void {
-    const previousSource = this.activeAudioClockSource;
     this.resetOutputTimestampValidation();
-    if (previousSource !== "estimated" && this._debugLogging) {
-      console.log(
-        `Sendspin: Audio clock source ${previousSource} -> estimated (${reason})`,
-      );
-    }
+    this._lastTimestampRejectReason = reason;
   }
 
   private getEstimatedAudioContextTimeSec(
@@ -429,6 +424,7 @@ export class AudioProcessor {
     this.outputTimestampLastSample = null;
     this.outputTimestampGoodSamples = 0;
     this.outputTimestampGoodSinceMs = null;
+    this._lastTimestampRejectReason = reason;
 
     if (this.activeAudioClockSource !== "timestamp") {
       this.outputTimestampBadSamples = 0;
@@ -587,6 +583,7 @@ export class AudioProcessor {
           "timestamp",
           `validated ${this.outputTimestampGoodSamples} samples over ${(nowMs - this.outputTimestampGoodSinceMs).toFixed(0)}ms`,
         );
+        this._lastTimestampRejectReason = null;
       }
 
       return predictedAudioTimeSec;

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,18 +263,6 @@ export class SendspinPlayer {
     this.audioProcessor.setCorrectionMode(mode);
   }
 
-  /**
-   * Enable or disable debug logging for sync corrections.
-   * When enabled, logs to console when correction method changes.
-   */
-  setDebugLogging(enabled: boolean): void {
-    this.audioProcessor.setDebugLogging(enabled);
-  }
-  // Get debug logging state
-  get debugLogging(): boolean {
-    return this.audioProcessor.debugLogging;
-  }
-
   // ========================================
   // Controller Commands (sent to server)
   // ========================================


### PR DESCRIPTION
Remove `setDebugLogging()` (breaking API change) and ~15 debug-gated log calls. Replace with a single always-on status line emitted every 10s while playing:

```
Sendspin: sync=+0.3ms corr=none q=4/1.2s resyncs=0 clock=timestamp(good:89) tf=synced(err=0.2ms,drift=0.001,n=60) lat=8ms mode=sync prec=precise ctx=running gen=1
```

Covers diagnosis of: not playing, stuttering, silence gaps, constant recorrection, and bad `getOutputTimestamp` devices. NativeOpus frame drops promoted to `console.warn` so decoder issues surface without debug mode.