### PR TITLE
Fix time filter drift covariance and adaptive forgetting bugs

### DIFF
--- a/src/time-filter.ts
+++ b/src/time-filter.ts
@@ -122,7 +122,7 @@ export class SendspinTimeFilter {
 
       // Drift variance estimated from propagation of offset uncertainties
       this._drift_covariance =
-        (this._offset_covariance + measurement_variance) / dt;
+        (this._offset_covariance + measurement_variance) / (dt * dt);
       this._offset_covariance = measurement_variance;
 
       this._current_time_element = {
@@ -167,7 +167,7 @@ export class SendspinTimeFilter {
     if (this._count < 100) {
       // Build sufficient history before enabling adaptive forgetting
       this._count += 1;
-    } else if (residual > max_residual_cutoff) {
+    } else if (Math.abs(residual) > max_residual_cutoff) {
       // Large prediction error detected - likely network disruption or clock adjustment
       // Apply forgetting factor to increase Kalman gain and accelerate convergence
       new_drift_covariance *= this._forget_variance_factor;


### PR DESCRIPTION
## Summary
- Fix drift covariance initialization: divide by dt² instead of dt (error propagation for finite difference)
- Fix adaptive forgetting: use Math.abs(residual) to trigger on both positive and negative clock jumps

## Details
These bugs were found by comparing the TypeScript implementation against the [reference C++ time filter](https://github.com/Sendspin/time-filter).

### Drift covariance (dt vs dt²)
The drift is estimated via finite differences: `drift = (measurement - offset) / dt`. By error propagation, `var(drift) = var(delta_offset) / dt²`. The code was dividing by `dt` instead of `dt²`, vastly overestimating the initial drift uncertainty (by a factor of ~dt), slowing drift convergence.

### Adaptive forgetting (missing abs)
The adaptive forgetting check used `residual > cutoff` instead of `Math.abs(residual) > cutoff`. This meant only positive residuals triggered forgetting. Negative residuals from backwards clock jumps would not trigger fast recovery.