### PR TITLE
Reduce scheduling horizon on Cast

### DIFF
--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -44,6 +44,9 @@ const SCHEDULE_HEADROOM_SEC = 0.2;
 const SCHEDULE_HORIZON_PRECISE_SEC = 20;
 const SCHEDULE_HORIZON_GOOD_SEC = 8;
 const SCHEDULE_HORIZON_POOR_SEC = 4;
+const CAST_SCHEDULE_HORIZON_PRECISE_SEC = 1.5;
+const CAST_SCHEDULE_HORIZON_GOOD_SEC = 1;
+const CAST_SCHEDULE_HORIZON_POOR_SEC = 0.5;
 const SCHEDULE_HORIZON_PRECISE_ERROR_MS = 2;
 const SCHEDULE_HORIZON_GOOD_ERROR_MS = 8;
 type AudioClockSource = "estimated" | "timestamp" | "raw";
@@ -192,6 +195,7 @@ export class AudioProcessor {
     private outputMode: AudioOutputMode = "direct",
     private audioElement?: HTMLAudioElement,
     private isAndroid: boolean = false,
+    private isCastRuntime: boolean = false,
     private ownsAudioElement: boolean = false,
     private silentAudioSrc?: string,
     private syncDelayMs: number = 0,
@@ -272,14 +276,23 @@ export class AudioProcessor {
   }
 
   private getTargetScheduledHorizonSec(): number {
+    const preciseHorizonSec = this.isCastRuntime
+      ? CAST_SCHEDULE_HORIZON_PRECISE_SEC
+      : SCHEDULE_HORIZON_PRECISE_SEC;
+    const goodHorizonSec = this.isCastRuntime
+      ? CAST_SCHEDULE_HORIZON_GOOD_SEC
+      : SCHEDULE_HORIZON_GOOD_SEC;
+    const poorHorizonSec = this.isCastRuntime
+      ? CAST_SCHEDULE_HORIZON_POOR_SEC
+      : SCHEDULE_HORIZON_POOR_SEC;
     const errorMs = this.timeFilter.error / 1000;
     if (errorMs < SCHEDULE_HORIZON_PRECISE_ERROR_MS) {
-      return SCHEDULE_HORIZON_PRECISE_SEC;
+      return preciseHorizonSec;
     }
     if (errorMs <= SCHEDULE_HORIZON_GOOD_ERROR_MS) {
-      return SCHEDULE_HORIZON_GOOD_SEC;
+      return goodHorizonSec;
     }
-    return SCHEDULE_HORIZON_POOR_SEC;
+    return poorHorizonSec;
   }
 
   private getScheduledAheadSec(currentTimeSec: number): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,4 +407,10 @@ export * from "./types";
 export { SendspinTimeFilter } from "./time-filter";
 
 // Export platform detection utilities
-export { detectIsAndroid, detectIsIOS, detectIsMobile, getDefaultSyncDelay };
+export {
+  detectIsAndroid,
+  detectIsIOS,
+  detectIsMobile,
+  detectIsCastRuntime,
+  getDefaultSyncDelay,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,11 @@ function detectIsMobile(): boolean {
   return detectIsAndroid() || detectIsIOS();
 }
 
+function detectIsCastRuntime(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /CrKey/i.test(navigator.userAgent);
+}
+
 function detectIsSafari(): boolean {
   if (typeof navigator === "undefined") return false;
   const ua = navigator.userAgent;
@@ -85,6 +90,7 @@ export class SendspinPlayer {
 
     // Auto-detect platform
     const isAndroid = detectIsAndroid();
+    const isCastRuntime = detectIsCastRuntime();
     const isMobile = detectIsMobile();
 
     // Determine output mode:
@@ -128,6 +134,7 @@ export class SendspinPlayer {
       outputMode,
       config.audioElement,
       isAndroid,
+      isCastRuntime,
       this.ownsAudioElement,
       isAndroid ? SILENT_AUDIO_SRC : undefined,
       config.syncDelay ?? getDefaultSyncDelay(),


### PR DESCRIPTION
When running on Cast receivers, `AudioProcessor` now uses a much shorter scheduling horizon.
This seams to reduce stuttering and disconnects, especially on the Nest Hub.
Total buffer size stays the same; the scheduling horizon just limits how much in advance audio is passed to the browser’s playback pipeline.