### PR TITLE
Reduce playback gaps after disconnects

### DIFF
--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -49,6 +49,9 @@ const CAST_SCHEDULE_HORIZON_GOOD_SEC = 1;
 const CAST_SCHEDULE_HORIZON_POOR_SEC = 0.5;
 const SCHEDULE_HORIZON_PRECISE_ERROR_MS = 2;
 const SCHEDULE_HORIZON_GOOD_ERROR_MS = 8;
+const SCHEDULE_REFILL_THRESHOLD_FRACTION = 0.5;
+const SCHEDULE_REFILL_MIN_THRESHOLD_SEC = 0.1;
+const SCHEDULE_REFILL_MAX_THRESHOLD_SEC = 5;
 type AudioClockSource = "estimated" | "timestamp" | "raw";
 
 interface OutputTimestampSample {
@@ -1642,12 +1645,15 @@ export class AudioProcessor {
   }
 
   private scheduleTimeout: ReturnType<typeof setTimeout> | null = null;
+  private refillTimeout: ReturnType<typeof setTimeout> | null = null;
   private queueProcessScheduled = false;
 
   // Schedule queue processing without starvation.
   // Uses a short timeout to allow out-of-order async decodes (FLAC) to batch.
   // TODO: Consider a "max-wait" watchdog if timer throttling/clamping causes excessive scheduling latency.
   private scheduleQueueProcessing(): void {
+    this.cancelScheduledRefill();
+
     if (this.queueProcessScheduled) {
       return;
     }
@@ -1677,6 +1683,66 @@ export class AudioProcessor {
     } else {
       Promise.resolve().then(run);
     }
+  }
+
+  private cancelScheduledRefill(): void {
+    if (this.refillTimeout !== null) {
+      clearTimeout(this.refillTimeout);
+      this.refillTimeout = null;
+    }
+  }
+
+  private getScheduledRefillThresholdSec(
+    targetScheduledHorizonSec: number,
+  ): number {
+    return Math.max(
+      SCHEDULE_REFILL_MIN_THRESHOLD_SEC,
+      Math.min(
+        SCHEDULE_REFILL_MAX_THRESHOLD_SEC,
+        targetScheduledHorizonSec * SCHEDULE_REFILL_THRESHOLD_FRACTION,
+      ),
+    );
+  }
+
+  private scheduleQueueRefill(targetScheduledHorizonSec: number): void {
+    this.cancelScheduledRefill();
+
+    if (
+      !this.audioContext ||
+      this.audioContext.state !== "running" ||
+      !this.stateManager.isPlaying ||
+      this.audioBufferQueue.length === 0
+    ) {
+      return;
+    }
+
+    const currentTimeSec = this.audioContext.currentTime;
+    this.pruneExpiredScheduledSources(currentTimeSec);
+    const scheduledAheadSec = this.getScheduledAheadSec(currentTimeSec);
+    const refillThresholdSec = this.getScheduledRefillThresholdSec(
+      targetScheduledHorizonSec,
+    );
+
+    if (scheduledAheadSec <= refillThresholdSec) {
+      this.scheduleQueueProcessing();
+      return;
+    }
+
+    this.refillTimeout = setTimeout(
+      () => {
+        this.refillTimeout = null;
+        if (
+          !this.audioContext ||
+          this.audioContext.state !== "running" ||
+          !this.stateManager.isPlaying ||
+          this.audioBufferQueue.length === 0
+        ) {
+          return;
+        }
+        this.scheduleQueueProcessing();
+      },
+      (scheduledAheadSec - refillThresholdSec) * 1000,
+    );
   }
 
   // Queue Opus packet to native decoder for async decoding (non-blocking)
@@ -1891,6 +1957,8 @@ export class AudioProcessor {
 
   // Process the audio queue and schedule chunks in order
   processAudioQueue(): void {
+    this.cancelScheduledRefill();
+
     if (!this.audioContext || !this.gainNode) return;
     if (this.audioContext.state !== "running") return;
 
@@ -2148,6 +2216,7 @@ export class AudioProcessor {
         }
       };
     }
+    this.scheduleQueueRefill(targetScheduledHorizonSec);
     this.emitStatusLog(nowMs);
   }
 
@@ -2190,6 +2259,7 @@ export class AudioProcessor {
   // Clear all audio buffers and scheduled sources
   clearBuffers(): void {
     this.stopRecorrectionMonitor();
+    this.cancelScheduledRefill();
 
     // Stop all scheduled audio sources
     this.scheduledSources.forEach((entry) => {

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -855,6 +855,23 @@ export class AudioProcessor {
     return this.syncDelayMs;
   }
 
+  // Refresh expired scheduled-source bookkeeping before measuring how much
+  // queued and already-scheduled audio remains available for playback.
+  measureBufferedPlaybackRunwaySec(): number {
+    if (!this.audioContext) {
+      return 0;
+    }
+
+    const currentTimeSec = this.audioContext.currentTime;
+    this.pruneExpiredScheduledSources(currentTimeSec);
+    const scheduledAheadSec = this.getScheduledAheadSec(currentTimeSec);
+    const queuedAheadSec = this.audioBufferQueue.reduce(
+      (totalSec, chunk) => totalSec + chunk.buffer.duration,
+      0,
+    );
+    return Math.max(0, scheduledAheadSec + queuedAheadSec);
+  }
+
   // Update sync delay at runtime
   setSyncDelay(delayMs: number): void {
     const sanitizedDelayMs = this.sanitizeSyncDelayMs(delayMs);

--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -1728,21 +1728,37 @@ export class AudioProcessor {
       return;
     }
 
-    this.refillTimeout = setTimeout(
-      () => {
-        this.refillTimeout = null;
-        if (
-          !this.audioContext ||
-          this.audioContext.state !== "running" ||
-          !this.stateManager.isPlaying ||
-          this.audioBufferQueue.length === 0
-        ) {
-          return;
-        }
-        this.scheduleQueueProcessing();
-      },
-      (scheduledAheadSec - refillThresholdSec) * 1000,
-    );
+    const runRefill = () => {
+      this.refillTimeout = null;
+      if (
+        !this.audioContext ||
+        this.audioContext.state !== "running" ||
+        !this.stateManager.isPlaying ||
+        this.audioBufferQueue.length === 0
+      ) {
+        return;
+      }
+      this.scheduleQueueProcessing();
+    };
+
+    const delayMs = (scheduledAheadSec - refillThresholdSec) * 1000;
+    if (typeof globalThis.setTimeout === "function") {
+      this.refillTimeout = globalThis.setTimeout(runRefill, delayMs);
+      return;
+    }
+
+    this.refillTimeout = null;
+    if (
+      typeof (globalThis as unknown as { queueMicrotask?: unknown })
+        .queueMicrotask === "function"
+    ) {
+      (
+        globalThis as unknown as { queueMicrotask: (cb: () => void) => void }
+      ).queueMicrotask(runRefill);
+      return;
+    }
+
+    void Promise.resolve().then(runRefill);
   }
 
   // Queue Opus packet to native decoder for async decoding (non-blocking)

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,12 +71,18 @@ function generateRandomId(): string {
   return Math.random().toString(36).substring(2, 6);
 }
 
+// Add a small cushion beyond the measured buffered runway so delayed timer
+// delivery does not cut playback off just before the last scheduled audio ends.
+const DISCONNECT_PLAYBACK_RESET_GRACE_MS = 250;
+
 export class SendspinPlayer {
   private wsManager: WebSocketManager;
   private audioProcessor: AudioProcessor;
   private protocolHandler: ProtocolHandler;
   private stateManager: StateManager;
   private timeFilter: SendspinTimeFilter;
+  private disconnectPlaybackResetTimeout: ReturnType<typeof setTimeout> | null =
+    null;
 
   private config: SendspinPlayerConfig;
   private wsUrl: string = "";
@@ -167,6 +173,44 @@ export class SendspinPlayer {
     );
   }
 
+  private cancelPendingDisconnectPlaybackReset(): void {
+    if (this.disconnectPlaybackResetTimeout !== null) {
+      clearTimeout(this.disconnectPlaybackResetTimeout);
+      this.disconnectPlaybackResetTimeout = null;
+    }
+  }
+
+  private resetPlaybackStateAfterDisconnect(): void {
+    if (this.wsManager.isConnected()) {
+      return;
+    }
+    this.disconnectPlaybackResetTimeout = null;
+    this.audioProcessor.clearBuffers();
+    this.stateManager.currentStreamFormat = null;
+    this.stateManager.isPlaying = false;
+    this.audioProcessor.stopAudioElement();
+    if (typeof navigator !== "undefined" && navigator.mediaSession) {
+      navigator.mediaSession.playbackState = "paused";
+    }
+  }
+
+  private scheduleDisconnectPlaybackReset(): void {
+    this.cancelPendingDisconnectPlaybackReset();
+
+    const runwaySec = this.audioProcessor.measureBufferedPlaybackRunwaySec();
+    if (runwaySec <= 0) {
+      this.resetPlaybackStateAfterDisconnect();
+      return;
+    }
+
+    this.disconnectPlaybackResetTimeout = setTimeout(
+      () => {
+        this.resetPlaybackStateAfterDisconnect();
+      },
+      runwaySec * 1000 + DISCONNECT_PLAYBACK_RESET_GRACE_MS,
+    );
+  }
+
   // Connect to Sendspin server
   async connect(): Promise<void> {
     // Build WebSocket URL
@@ -179,6 +223,7 @@ export class SendspinPlayer {
       this.wsUrl,
       // onOpen
       () => {
+        this.cancelPendingDisconnectPlaybackReset();
         console.log("Sendspin: Using player_id:", this.config.playerId);
         this.protocolHandler.sendClientHello();
       },
@@ -193,6 +238,8 @@ export class SendspinPlayer {
       // onClose
       () => {
         this.protocolHandler.stopTimeSync();
+        this.stateManager.clearStateUpdateInterval();
+        this.scheduleDisconnectPlaybackReset();
         console.log("Sendspin: Connection closed");
       },
     );
@@ -207,6 +254,8 @@ export class SendspinPlayer {
    *   - 'user_request': User explicitly requested to disconnect
    */
   disconnect(reason: GoodbyeReason = "shutdown"): void {
+    this.cancelPendingDisconnectPlaybackReset();
+
     // Send goodbye message if connected
     if (this.wsManager.isConnected()) {
       this.protocolHandler.sendGoodbye(reason);

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,10 +182,10 @@ export class SendspinPlayer {
   }
 
   private resetPlaybackStateAfterDisconnect(): void {
+    this.disconnectPlaybackResetTimeout = null;
     if (this.wsManager.isConnected()) {
       return;
     }
-    this.disconnectPlaybackResetTimeout = null;
     this.audioProcessor.clearBuffers();
     this.stateManager.currentStreamFormat = null;
     this.stateManager.isPlaying = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export class SendspinPlayer {
   private timeFilter: SendspinTimeFilter;
   private disconnectPlaybackResetTimeout: ReturnType<typeof setTimeout> | null =
     null;
+  private suppressDisconnectPlaybackReset = false;
 
   private config: SendspinPlayerConfig;
   private wsUrl: string = "";
@@ -213,6 +214,8 @@ export class SendspinPlayer {
 
   // Connect to Sendspin server
   async connect(): Promise<void> {
+    this.suppressDisconnectPlaybackReset = false;
+
     // Build WebSocket URL
     const url = new URL(this.config.baseUrl);
     const wsProtocol = url.protocol === "https:" ? "wss:" : "ws:";
@@ -238,6 +241,10 @@ export class SendspinPlayer {
       // onClose
       () => {
         this.protocolHandler.stopTimeSync();
+        if (this.suppressDisconnectPlaybackReset) {
+          console.log("Sendspin: Connection closed");
+          return;
+        }
         this.stateManager.clearStateUpdateInterval();
         this.scheduleDisconnectPlaybackReset();
         console.log("Sendspin: Connection closed");
@@ -255,6 +262,7 @@ export class SendspinPlayer {
    */
   disconnect(reason: GoodbyeReason = "shutdown"): void {
     this.cancelPendingDisconnectPlaybackReset();
+    this.suppressDisconnectPlaybackReset = true;
 
     // Send goodbye message if connected
     if (this.wsManager.isConnected()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,13 +241,12 @@ export class SendspinPlayer {
       // onClose
       () => {
         this.protocolHandler.stopTimeSync();
+        console.log("Sendspin: Connection closed");
         if (this.suppressDisconnectPlaybackReset) {
-          console.log("Sendspin: Connection closed");
           return;
         }
         this.stateManager.clearStateUpdateInterval();
         this.scheduleDisconnectPlaybackReset();
-        console.log("Sendspin: Connection closed");
       },
     );
   }


### PR DESCRIPTION
Keep locally buffered audio running WebSocket connection drops instead of clearing playback immediately:
- `SendspinPlayer` now defers the hard reset until the buffered runway is exhausted
- `AudioProcessor` keeps small scheduling horizons from already-decoded audio so queued data continues to play while reconnecting