### PR TITLE
Disable output timestamps on Cast

### DIFF
--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -411,6 +411,18 @@ export class AudioProcessor {
   }
 
   private getTimestampDerivedAudioTimeSec(rawTimeSec: number): number | null {
+    if (this.isCastRuntime) {
+      if (
+        this.activeAudioClockSource !== "estimated" ||
+        this.outputTimestampLastSample !== null ||
+        this.outputTimestampGoodSamples !== 0 ||
+        this._lastTimestampRejectReason !== null
+      ) {
+        this.resetOutputTimestampValidation();
+      }
+      return null;
+    }
+
     if (!this.audioContext) {
       return null;
     }
@@ -956,7 +968,9 @@ export class AudioProcessor {
 
     // clock field
     let clock: string;
-    if (this.activeAudioClockSource === "timestamp") {
+    if (this.isCastRuntime) {
+      clock = "estimated(cast-disabled)";
+    } else if (this.activeAudioClockSource === "timestamp") {
       clock = `timestamp(good:${this.outputTimestampGoodSamples})`;
     } else if (this._lastTimestampRejectReason) {
       clock = `estimated(reject:"${this._lastTimestampRejectReason}")`;


### PR DESCRIPTION
Keep Cast players on the estimated audio clock instead of trying to promote to `getOutputTimestamp()`.
This avoids audible rate oscillations on Nest Hubs.