### PR TITLE
Use fixed 1.5s scheduling horizon on Cast

### DIFF
--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -44,9 +44,7 @@ const SCHEDULE_HEADROOM_SEC = 0.2;
 const SCHEDULE_HORIZON_PRECISE_SEC = 20;
 const SCHEDULE_HORIZON_GOOD_SEC = 8;
 const SCHEDULE_HORIZON_POOR_SEC = 4;
-const CAST_SCHEDULE_HORIZON_PRECISE_SEC = 1.5;
-const CAST_SCHEDULE_HORIZON_GOOD_SEC = 1;
-const CAST_SCHEDULE_HORIZON_POOR_SEC = 0.5;
+const CAST_SCHEDULE_HORIZON_SEC = 1.5;
 const SCHEDULE_HORIZON_PRECISE_ERROR_MS = 2;
 const SCHEDULE_HORIZON_GOOD_ERROR_MS = 8;
 const SCHEDULE_REFILL_THRESHOLD_FRACTION = 0.5;
@@ -279,23 +277,17 @@ export class AudioProcessor {
   }
 
   private getTargetScheduledHorizonSec(): number {
-    const preciseHorizonSec = this.isCastRuntime
-      ? CAST_SCHEDULE_HORIZON_PRECISE_SEC
-      : SCHEDULE_HORIZON_PRECISE_SEC;
-    const goodHorizonSec = this.isCastRuntime
-      ? CAST_SCHEDULE_HORIZON_GOOD_SEC
-      : SCHEDULE_HORIZON_GOOD_SEC;
-    const poorHorizonSec = this.isCastRuntime
-      ? CAST_SCHEDULE_HORIZON_POOR_SEC
-      : SCHEDULE_HORIZON_POOR_SEC;
+    if (this.isCastRuntime) {
+      return CAST_SCHEDULE_HORIZON_SEC;
+    }
     const errorMs = this.timeFilter.error / 1000;
     if (errorMs < SCHEDULE_HORIZON_PRECISE_ERROR_MS) {
-      return preciseHorizonSec;
+      return SCHEDULE_HORIZON_PRECISE_SEC;
     }
     if (errorMs <= SCHEDULE_HORIZON_GOOD_ERROR_MS) {
-      return goodHorizonSec;
+      return SCHEDULE_HORIZON_GOOD_SEC;
     }
-    return poorHorizonSec;
+    return SCHEDULE_HORIZON_POOR_SEC;
   }
 
   private getScheduledAheadSec(currentTimeSec: number): number {


### PR DESCRIPTION
The precision-based tiers (1.5/1/0.5s) caused unnecessarily short horizons during the start of the playback on Cast devices. 

Now scheduling is always fixed to 1.5s to prevent stuttering on some devices while the clock hasn't converged yet (like on my Google Home Mini).