### PR TITLE
Gate gap resync on cooldown

### DIFF
--- a/src/audio-processor.ts
+++ b/src/audio-processor.ts
@@ -2171,10 +2171,12 @@ export class AudioProcessor {
           }
         } else {
           // Gap detected in server timestamps - hard resync
-          this.noteHardResync(nowMs);
-          this.resyncCount++;
-          this._intervalResyncCount++;
-          this.cutScheduledSources(targetPlaybackTime - syncDelaySec);
+          if (this.canUseHardResync(nowMs)) {
+            this.noteHardResync(nowMs);
+            this.resyncCount++;
+            this._intervalResyncCount++;
+            this.cutScheduledSources(targetPlaybackTime - syncDelaySec);
+          }
           playbackTime = targetPlaybackTime;
           scheduleTime = playbackTime - syncDelaySec;
           playbackRate = 1.0;


### PR DESCRIPTION
The gap resync path (server timestamp discontinuity) was the only resync path without a cooldown check. It could fire per-chunk in the `processAudioQueue` while loop, causing resync cascades during startup on Cast devices.

Gate the destructive `cutScheduledSources` and counter increment on `canUseHardResync()`, which enforces the 500ms cooldown and startup grace. The chunk still schedules at `targetPlaybackTime` regardless, preserving correct timing for genuine discontinuities.