### PR TITLE
Add configurable reconnect with exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,7 @@ const player = new SendspinPlayer({
     baseDelayMs: 1000,
     maxDelayMs: 15000,
     maxAttempts: 7,
-    onReconnecting: ({ attempt, delayMs }) => {
-      console.log(`Reconnecting in ${delayMs}ms (attempt ${attempt})`);
-    },
+    onReconnecting: (attempt) => console.log(`Reconnecting (attempt ${attempt})`),
     onReconnected: () => console.log('Reconnected'),
     onExhausted: () => console.log('Giving up'),
   },

--- a/README.md
+++ b/README.md
@@ -84,6 +84,31 @@ const player = new SendspinPlayer({
 await player.connect();
 ```
 
+### Reconnect behavior
+
+Built-in auto-reconnect uses exponential backoff (1s → 15s, unlimited
+attempts). Override the bounds, cap the retry count, or hook callbacks to
+drive UI and fatal-error paths via `reconnect`.
+
+```typescript
+const player = new SendspinPlayer({
+  baseUrl: 'http://your-server:8095',
+  reconnect: {
+    baseDelayMs: 1000,
+    maxDelayMs: 15000,
+    maxAttempts: 7,
+    onReconnecting: ({ attempt, delayMs }) => {
+      console.log(`Reconnecting in ${delayMs}ms (attempt ${attempt})`);
+    },
+    onReconnected: () => console.log('Reconnected'),
+    onExhausted: () => console.log('Giving up'),
+  },
+});
+```
+
+Reconnection only applies to connections opened via `baseUrl`; adopted
+sockets (`webSocket`) never auto-reconnect.
+
 ### Tuning correction thresholds
 
 Override the per-mode thresholds that control when/how the scheduler corrects

--- a/public/app.js
+++ b/public/app.js
@@ -567,6 +567,16 @@ async function connect() {
       syncDelay: sanitizedSyncDelay,
       correctionMode: savedCorrectionMode,
       correctionThresholds,
+      reconnect: {
+        onReconnecting: ({ attempt, delayMs }) => {
+          showToast(
+            `Reconnecting in ${Math.round(delayMs / 1000)}s (attempt ${attempt})`,
+            "info",
+          );
+        },
+        onReconnected: () => showToast("Reconnected", "success"),
+        onExhausted: () => showToast("Reconnect failed", "error"),
+      },
       onStateChange,
     });
 

--- a/public/app.js
+++ b/public/app.js
@@ -568,12 +568,8 @@ async function connect() {
       correctionMode: savedCorrectionMode,
       correctionThresholds,
       reconnect: {
-        onReconnecting: ({ attempt, delayMs }) => {
-          showToast(
-            `Reconnecting in ${Math.round(delayMs / 1000)}s (attempt ${attempt})`,
-            "info",
-          );
-        },
+        onReconnecting: (attempt) =>
+          showToast(`Reconnecting (attempt ${attempt})`, "info"),
         onReconnected: () => showToast("Reconnected", "success"),
         onExhausted: () => showToast("Reconnect failed", "error"),
       },

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -69,7 +69,7 @@ export class SendspinCore implements StreamHandler {
       () => this.stateManager.streamGeneration,
     );
 
-    this.wsManager = new WebSocketManager();
+    this.wsManager = new WebSocketManager(config.reconnect);
 
     this.protocolHandler = new ProtocolHandler(
       playerId,

--- a/src/core/websocket-manager.ts
+++ b/src/core/websocket-manager.ts
@@ -1,8 +1,18 @@
-import type { ClientMessage } from "../types";
+import type { ClientMessage, ReconnectConfig } from "../types";
+
 export class WebSocketManager {
   private ws: WebSocket | null = null;
   private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
   private shouldReconnect: boolean = false;
+  private isReconnecting: boolean = false;
+  private reconnectAttempt: number = 0;
+
+  private baseDelayMs: number;
+  private maxDelayMs: number;
+  private maxAttempts: number;
+  private onReconnecting?: ReconnectConfig["onReconnecting"];
+  private onReconnected?: ReconnectConfig["onReconnected"];
+  private onExhausted?: ReconnectConfig["onExhausted"];
 
   // Event handlers
   private onOpenHandler?: () => void;
@@ -10,7 +20,17 @@ export class WebSocketManager {
   private onErrorHandler?: (error: Event) => void;
   private onCloseHandler?: () => void;
 
-  constructor() {}
+  constructor(config?: ReconnectConfig) {
+    this.baseDelayMs = Math.max(0, config?.baseDelayMs ?? 1000);
+    this.maxDelayMs = Math.max(this.baseDelayMs, config?.maxDelayMs ?? 15000);
+    this.maxAttempts =
+      config?.maxAttempts === undefined
+        ? Infinity
+        : Math.max(0, config.maxAttempts);
+    this.onReconnecting = config?.onReconnecting;
+    this.onReconnected = config?.onReconnected;
+    this.onExhausted = config?.onExhausted;
+  }
 
   /**
    * Adopt an existing WebSocket connection.
@@ -58,6 +78,7 @@ export class WebSocketManager {
     this.ws.binaryType = "arraybuffer";
     // No auto-reconnect for externally-managed sockets
     this.shouldReconnect = false;
+    this.clearReconnectState();
 
     this.ws.onmessage = (event: MessageEvent) => {
       if (this.onMessageHandler) {
@@ -128,6 +149,10 @@ export class WebSocketManager {
       this.ws = null;
     }
 
+    return this.openSocket(url);
+  }
+
+  private openSocket(url: string): Promise<void> {
     return new Promise((resolve, reject) => {
       try {
         console.log("Sendspin: Connecting to", url);
@@ -138,8 +163,14 @@ export class WebSocketManager {
 
         this.ws.onopen = () => {
           console.log("Sendspin: WebSocket connected");
+          const wasReconnecting = this.isReconnecting;
+          this.isReconnecting = false;
+          this.reconnectAttempt = 0;
           if (this.onOpenHandler) {
             this.onOpenHandler();
+          }
+          if (wasReconnecting) {
+            this.onReconnected?.();
           }
           resolve();
         };
@@ -176,36 +207,64 @@ export class WebSocketManager {
     });
   }
 
+  private getReconnectDelayMs(attempt: number): number {
+    const exponential = this.baseDelayMs * 2 ** (attempt - 1);
+    return Math.min(exponential, this.maxDelayMs);
+  }
+
   // Schedule reconnection attempt
   private scheduleReconnect(url: string): void {
     if (this.reconnectTimeout !== null) {
       clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = null;
     }
 
+    const attempt = this.reconnectAttempt + 1;
+    if (attempt > this.maxAttempts) {
+      console.warn(
+        `Sendspin: Reconnect exhausted after ${this.maxAttempts} attempt(s)`,
+      );
+      this.shouldReconnect = false;
+      this.isReconnecting = false;
+      this.reconnectAttempt = 0;
+      this.onExhausted?.();
+      return;
+    }
+
+    this.reconnectAttempt = attempt;
+    this.isReconnecting = true;
+    const delayMs = this.getReconnectDelayMs(attempt);
+
     this.reconnectTimeout = globalThis.setTimeout(() => {
-      if (this.shouldReconnect) {
-        console.log("Sendspin: Attempting to reconnect...");
-        this.connect(
-          url,
-          this.onOpenHandler,
-          this.onMessageHandler,
-          this.onErrorHandler,
-          this.onCloseHandler,
-        ).catch((error) => {
-          console.error("Sendspin: Reconnection failed", error);
-        });
+      this.reconnectTimeout = null;
+      if (!this.shouldReconnect) {
+        return;
       }
-    }, 5000);
+      this.onReconnecting?.({ attempt, delayMs });
+      console.log(
+        `Sendspin: Attempting to reconnect (attempt ${attempt}${
+          this.maxAttempts === Infinity ? "" : `/${this.maxAttempts}`
+        })...`,
+      );
+      this.openSocket(url).catch((error) => {
+        console.error("Sendspin: Reconnection failed", error);
+      });
+    }, delayMs);
+  }
+
+  private clearReconnectState(): void {
+    if (this.reconnectTimeout !== null) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = null;
+    }
+    this.isReconnecting = false;
+    this.reconnectAttempt = 0;
   }
 
   // Disconnect from WebSocket server
   disconnect(): void {
     this.shouldReconnect = false;
-
-    if (this.reconnectTimeout !== null) {
-      clearTimeout(this.reconnectTimeout);
-      this.reconnectTimeout = null;
-    }
+    this.clearReconnectState();
 
     if (this.ws) {
       this.ws.close();

--- a/src/core/websocket-manager.ts
+++ b/src/core/websocket-manager.ts
@@ -143,9 +143,17 @@ export class WebSocketManager {
     this.onErrorHandler = onError;
     this.onCloseHandler = onClose;
 
-    // Disconnect if already connected
+    // Detach the old socket before replacing it: its async onclose would
+    // otherwise re-enter scheduleReconnect once openSocket re-arms retry.
+    this.shouldReconnect = false;
+    this.clearReconnectState();
     if (this.ws) {
-      this.ws.close();
+      const old = this.ws;
+      old.onopen = null;
+      old.onmessage = null;
+      old.onerror = null;
+      old.onclose = null;
+      old.close();
       this.ws = null;
     }
 

--- a/src/core/websocket-manager.ts
+++ b/src/core/websocket-manager.ts
@@ -248,7 +248,7 @@ export class WebSocketManager {
       if (!this.shouldReconnect) {
         return;
       }
-      this.onReconnecting?.({ attempt, delayMs });
+      this.onReconnecting?.(attempt);
       console.log(
         `Sendspin: Attempting to reconnect (attempt ${attempt}${
           this.maxAttempts === Infinity ? "" : `/${this.maxAttempts}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,7 @@ export class SendspinPlayer {
       onVolumeCommand: config.onVolumeCommand,
       onDelayCommand: config.onDelayCommand,
       getExternalVolume: config.getExternalVolume,
+      reconnect: config.reconnect,
       onStateChange: config.onStateChange,
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -352,6 +352,65 @@ export interface DecodedAudioChunk {
 }
 
 /**
+ * Information about a reconnect attempt.
+ */
+export interface ReconnectAttemptInfo {
+  /** 1-based attempt counter. */
+  attempt: number;
+  /** Delay (ms) before this attempt fires. */
+  delayMs: number;
+}
+
+/**
+ * Reconnection behavior when the WebSocket closes unexpectedly.
+ *
+ * Defaults: exponential backoff starting at 1s, capped at 15s, unlimited attempts.
+ * Reconnection is only active for connections opened via `baseUrl` — adopted
+ * sockets (via `webSocket`) never auto-reconnect.
+ */
+export interface ReconnectConfig {
+  /**
+   * Base delay in ms for the first reconnect attempt.
+   * Subsequent attempts double this up to `maxDelayMs`.
+   *
+   * Default: 1000
+   */
+  baseDelayMs?: number;
+
+  /**
+   * Upper bound for the exponential backoff delay in ms.
+   *
+   * Default: 15000
+   */
+  maxDelayMs?: number;
+
+  /**
+   * Maximum number of reconnect attempts before giving up and firing
+   * `onExhausted`. Pass `Infinity` for unlimited retries.
+   *
+   * Default: Infinity
+   */
+  maxAttempts?: number;
+
+  /**
+   * Called before each reconnect attempt fires (after the delay has elapsed
+   * but before the WebSocket is created).
+   */
+  onReconnecting?: (info: ReconnectAttemptInfo) => void;
+
+  /**
+   * Called once the socket re-opens successfully after one or more retries.
+   */
+  onReconnected?: () => void;
+
+  /**
+   * Called when `maxAttempts` is reached without a successful reconnect.
+   * After this fires, the manager stops retrying automatically.
+   */
+  onExhausted?: () => void;
+}
+
+/**
  * Configuration for SendspinCore (protocol + decoding, no playback).
  */
 export interface SendspinCoreConfig {
@@ -430,6 +489,12 @@ export interface SendspinCoreConfig {
    * Not called immediately after volume commands to wait for hardware to apply the change.
    */
   getExternalVolume?: () => { volume: number; muted: boolean };
+
+  /**
+   * Reconnection behavior for connections opened via `baseUrl`.
+   * See {@link ReconnectConfig} for defaults.
+   */
+  reconnect?: ReconnectConfig;
 
   /** Callback when player state changes (local or from server). */
   onStateChange?: (state: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -352,16 +352,6 @@ export interface DecodedAudioChunk {
 }
 
 /**
- * Information about a reconnect attempt.
- */
-export interface ReconnectAttemptInfo {
-  /** 1-based attempt counter. */
-  attempt: number;
-  /** Delay (ms) before this attempt fires. */
-  delayMs: number;
-}
-
-/**
  * Reconnection behavior when the WebSocket closes unexpectedly.
  *
  * Defaults: exponential backoff starting at 1s, capped at 15s, unlimited attempts.
@@ -393,10 +383,10 @@ export interface ReconnectConfig {
   maxAttempts?: number;
 
   /**
-   * Called before each reconnect attempt fires (after the delay has elapsed
-   * but before the WebSocket is created).
+   * Called immediately before each reconnect attempt opens a new socket.
+   * `attempt` is 1-based.
    */
-  onReconnecting?: (info: ReconnectAttemptInfo) => void;
+  onReconnecting?: (attempt: number) => void;
 
   /**
    * Called once the socket re-opens successfully after one or more retries.


### PR DESCRIPTION
`WebSocketManager` retried with a fixed 5s delay and no exponential backoff. This was especially limiting for the Cast App where we want to stop the App after the server couldn't be reached after a couple connection attempts.
The cast App previously had a custom reconnect strategy, but that was interfearing with the builtin one in `sendspin-js` (removed in https://github.com/Sendspin/cast/pull/77).

## Summary

New `reconnect` option on `SendspinCoreConfig` exposes exponential backoff bounds (`baseDelayMs`, `maxDelayMs`), a `maxAttempts` cutoff, and `onReconnecting` / `onReconnected` / `onExhausted` callbacks. Defaults switch from fixed 5s to 1s to 15s exponential with unlimited attempts; callers that don't pass `reconnect` see no API change beyond the faster first retry.