### PR TITLE
Publish 2.x releases with `legacy` npm dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,4 +80,11 @@ jobs:
         run: npm version ${{ needs.build.outputs.version }} --no-git-tag-version
 
       - name: Publish release to npm
-        run: npm publish --access public --provenance
+        run: |
+          VERSION="${{ needs.build.outputs.version }}"
+          if [[ "$VERSION" =~ ^2\. ]]; then
+            echo "Publishing 2.x release with dist-tag 'legacy'"
+            npm publish --access public --provenance --tag legacy
+          else
+            npm publish --access public --provenance
+          fi


### PR DESCRIPTION
Releases run from `main`'s workflow regardless of the tagged ref. Without this, publishing a 2.x patch from `release/2.x` would silently demote npm `latest` to the older major.