### PR TITLE
Avoid duplicate `/sendspin` in WebSocket URL

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -213,7 +213,9 @@ export class SendspinCore implements StreamHandler {
       );
       const wsProtocol = url.protocol === "https:" ? "wss:" : "ws:";
       const basePath = url.pathname.replace(/\/$/, "");
-      const wsUrl = `${wsProtocol}//${url.host}${basePath}/sendspin`;
+      const wsUrl = basePath.endsWith("/sendspin")
+        ? `${wsProtocol}//${url.host}${basePath}`
+        : `${wsProtocol}//${url.host}${basePath}/sendspin`;
 
       await this.wsManager.connect(wsUrl, onOpen, onMessage, onError, onClose);
     }


### PR DESCRIPTION
Since #92 the WS URL preserves `baseUrl`'s pathname and still appends `/sendspin`. Callers that pass a `baseUrl` already ending in `/sendspin` (e.g. Music Assistant's `serverUrl` for the Cast App) end up with `/sendspin/sendspin` and fail to connect. Skip the append when the path already terminates in `/sendspin`.