### PR TITLE
Add support to advertise player timing capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,29 @@ const player = new SendspinPlayer({
 });
 ```
 
+### Buffer timing
+
+Report the startup lead time and ongoing jitter buffer the player needs to the
+server via `client/state`. Lower values mean lower latency at the risk of
+underruns. Defaults are `requiredLeadTimeMs: 250` and `minBufferMs: 250`.
+
+```typescript
+const player = new SendspinPlayer({
+  baseUrl: 'http://your-server:8095',
+  requiredLeadTimeMs: 250,  // startup warmup (codec init, decode, DAC)
+  minBufferMs: 250,         // ongoing buffer to absorb network jitter
+});
+```
+
+Both can be updated at runtime, e.g. after measuring real lead time post-warmup
+or on a link-type change. Debounce updates so transient fluctuations don't churn
+server-side timing.
+
+```typescript
+player.setRequiredLeadTimeMs(300);
+player.setMinBufferMs(1500);
+```
+
 ### Core + scheduler as separate layers
 
 Apps that need the decoded PCM stream (e.g. visualizers) can use

--- a/index.html
+++ b/index.html
@@ -242,6 +242,45 @@
             >
           </div>
           <div class="form-group">
+            <label for="required-lead-time">Required Lead Time (ms)</label>
+            <div class="sync-delay-row">
+              <input
+                type="number"
+                id="required-lead-time"
+                value="250"
+                min="0"
+                max="10000"
+                step="50"
+              />
+              <button id="apply-required-lead-time" class="btn btn-secondary">
+                Apply
+              </button>
+            </div>
+            <small
+              >Startup warmup reported to the server (codec init, decode,
+              DAC)</small
+            >
+          </div>
+          <div class="form-group">
+            <label for="min-buffer">Min Buffer (ms)</label>
+            <div class="sync-delay-row">
+              <input
+                type="number"
+                id="min-buffer"
+                value="250"
+                min="0"
+                max="10000"
+                step="50"
+              />
+              <button id="apply-min-buffer" class="btn btn-secondary">
+                Apply
+              </button>
+            </div>
+            <small
+              >Ongoing jitter buffer reported to the server</small
+            >
+          </div>
+          <div class="form-group">
             <label for="correction-mode">Correction Mode</label>
             <select id="correction-mode">
               <option value="sync">Sync (default)</option>

--- a/public/app.js
+++ b/public/app.js
@@ -23,6 +23,8 @@ const STORAGE_KEYS = {
   VOLUME: "sendspin-volume",
   MUTED: "sendspin-muted",
   SYNC_DELAY: "sendspin-sync-delay",
+  REQUIRED_LEAD_TIME: "sendspin-required-lead-time",
+  MIN_BUFFER: "sendspin-min-buffer",
   CORRECTION_MODE: "sendspin-correction-mode",
   RESYNC_THRESHOLD: "sendspin-resync-threshold",
   DEADBAND_THRESHOLD: "sendspin-deadband-threshold",
@@ -40,6 +42,12 @@ const muteBtn = document.getElementById("mute-btn");
 const muteIcon = document.getElementById("mute-icon");
 const syncDelayInput = document.getElementById("sync-delay");
 const applySyncDelayBtn = document.getElementById("apply-sync-delay");
+const requiredLeadTimeInput = document.getElementById("required-lead-time");
+const applyRequiredLeadTimeBtn = document.getElementById(
+  "apply-required-lead-time",
+);
+const minBufferInput = document.getElementById("min-buffer");
+const applyMinBufferBtn = document.getElementById("apply-min-buffer");
 const correctionModeSelect = document.getElementById("correction-mode");
 const resyncThresholdInput = document.getElementById("resync-threshold");
 const deadbandThresholdInput = document.getElementById("deadband-threshold");
@@ -424,6 +432,19 @@ function loadSettings() {
     syncDelayInput.value = sanitizeSyncDelay(parseInt(savedSyncDelay, 10));
   }
 
+  const savedLeadTime = localStorage.getItem(STORAGE_KEYS.REQUIRED_LEAD_TIME);
+  if (savedLeadTime !== null) {
+    requiredLeadTimeInput.value = sanitizeBufferMs(
+      parseInt(savedLeadTime, 10),
+      250,
+    );
+  }
+
+  const savedMinBuffer = localStorage.getItem(STORAGE_KEYS.MIN_BUFFER);
+  if (savedMinBuffer !== null) {
+    minBufferInput.value = sanitizeBufferMs(parseInt(savedMinBuffer, 10), 250);
+  }
+
   const savedCorrectionMode = localStorage.getItem(
     STORAGE_KEYS.CORRECTION_MODE,
   );
@@ -472,6 +493,13 @@ function sanitizeSyncDelay(delay) {
     return 0;
   }
   return Math.max(0, Math.min(5000, Math.round(delay)));
+}
+
+function sanitizeBufferMs(value, fallback) {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(0, Math.min(10000, Math.round(value)));
 }
 
 /**
@@ -560,11 +588,22 @@ async function connect() {
 
     const correctionThresholds = buildCorrectionThresholds(savedCorrectionMode);
 
+    const requiredLeadTimeMs = sanitizeBufferMs(
+      parseInt(requiredLeadTimeInput.value, 10),
+      250,
+    );
+    const minBufferMs = sanitizeBufferMs(
+      parseInt(minBufferInput.value, 10),
+      250,
+    );
+
     player = new SendspinPlayer({
       playerId: getPlayerId(),
       baseUrl: serverUrl,
       clientName: "Sendspin Sample Player",
       syncDelay: sanitizedSyncDelay,
+      requiredLeadTimeMs,
+      minBufferMs,
       correctionMode: savedCorrectionMode,
       correctionThresholds,
       reconnect: {
@@ -691,6 +730,31 @@ function applySyncDelay() {
 }
 
 /**
+ * Apply required lead time
+ */
+function applyRequiredLeadTime() {
+  const leadTime = sanitizeBufferMs(
+    parseInt(requiredLeadTimeInput.value, 10),
+    250,
+  );
+  requiredLeadTimeInput.value = leadTime;
+  localStorage.setItem(STORAGE_KEYS.REQUIRED_LEAD_TIME, leadTime.toString());
+  player?.setRequiredLeadTimeMs(leadTime);
+  showToast(`Required lead time set to ${leadTime}ms`, "success");
+}
+
+/**
+ * Apply min buffer
+ */
+function applyMinBuffer() {
+  const minBuffer = sanitizeBufferMs(parseInt(minBufferInput.value, 10), 250);
+  minBufferInput.value = minBuffer;
+  localStorage.setItem(STORAGE_KEYS.MIN_BUFFER, minBuffer.toString());
+  player?.setMinBufferMs(minBuffer);
+  showToast(`Min buffer set to ${minBuffer}ms`, "success");
+}
+
+/**
  * Apply correction mode
  */
 function applyCorrectionMode() {
@@ -732,6 +796,8 @@ function init() {
   volumeSlider.addEventListener("input", updateVolume);
   muteBtn.addEventListener("click", toggleMute);
   applySyncDelayBtn.addEventListener("click", applySyncDelay);
+  applyRequiredLeadTimeBtn.addEventListener("click", applyRequiredLeadTime);
+  applyMinBufferBtn.addEventListener("click", applyMinBuffer);
   correctionModeSelect.addEventListener("change", applyCorrectionMode);
   resyncThresholdInput?.addEventListener("change", () => {
     localStorage.setItem(
@@ -774,6 +840,18 @@ function init() {
   syncDelayInput.addEventListener("keydown", (e) => {
     if (e.key === "Enter") {
       applySyncDelay();
+    }
+  });
+
+  requiredLeadTimeInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      applyRequiredLeadTime();
+    }
+  });
+
+  minBufferInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      applyMinBuffer();
     }
   });
 

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -81,6 +81,8 @@ export class SendspinCore implements StreamHandler {
         clientName,
         codecs: config.codecs,
         bufferCapacity: config.bufferCapacity,
+        requiredLeadTimeMs: config.requiredLeadTimeMs,
+        minBufferMs: config.minBufferMs,
         useHardwareVolume: config.useHardwareVolume,
         onVolumeCommand: config.onVolumeCommand,
         onDelayCommand: config.onDelayCommand,
@@ -267,6 +269,18 @@ export class SendspinCore implements StreamHandler {
     this._syncDelayMs = clampSyncDelayMs(delayMs);
     this._onSyncDelayChange?.(this._syncDelayMs);
     this.protocolHandler.sendStateUpdate();
+  }
+
+  // ========================================
+  // Buffer timing
+  // ========================================
+
+  setRequiredLeadTimeMs(leadTimeMs: number): void {
+    this.protocolHandler.setRequiredLeadTimeMs(leadTimeMs);
+  }
+
+  setMinBufferMs(minBufferMs: number): void {
+    this.protocolHandler.setMinBufferMs(minBufferMs);
   }
 
   // ========================================

--- a/src/core/protocol-handler.ts
+++ b/src/core/protocol-handler.ts
@@ -28,10 +28,15 @@ import { clampSyncDelayMs } from "../sync-delay";
 // Constants
 const STATE_UPDATE_INTERVAL = 5000; // 5 seconds
 
+const DEFAULT_REQUIRED_LEAD_TIME_MS = 250;
+const DEFAULT_MIN_BUFFER_MS = 250;
+
 export interface ProtocolHandlerConfig {
   clientName?: string;
   codecs?: Codec[];
   bufferCapacity?: number;
+  requiredLeadTimeMs?: number;
+  minBufferMs?: number;
   useHardwareVolume?: boolean;
   onVolumeCommand?: (volume: number, muted: boolean) => void;
   onDelayCommand?: (delayMs: number) => void;
@@ -42,6 +47,8 @@ export class ProtocolHandler {
   private clientName: string;
   private codecs: Codec[];
   private bufferCapacity: number;
+  private requiredLeadTimeMs: number;
+  private minBufferMs: number;
   private useHardwareVolume: boolean;
   private onVolumeCommand?: (volume: number, muted: boolean) => void;
   private onDelayCommand?: (delayMs: number) => void;
@@ -59,6 +66,9 @@ export class ProtocolHandler {
     this.clientName = config.clientName ?? "Sendspin Player";
     this.codecs = config.codecs ?? ["opus", "flac", "pcm"];
     this.bufferCapacity = config.bufferCapacity ?? 1024 * 1024 * 5; // 5MB default
+    this.requiredLeadTimeMs =
+      config.requiredLeadTimeMs ?? DEFAULT_REQUIRED_LEAD_TIME_MS;
+    this.minBufferMs = config.minBufferMs ?? DEFAULT_MIN_BUFFER_MS;
     this.useHardwareVolume = config.useHardwareVolume ?? false;
     this.onVolumeCommand = config.onVolumeCommand;
     this.onDelayCommand = config.onDelayCommand;
@@ -284,6 +294,16 @@ export class ProtocolHandler {
     this.wsManager.send(hello);
   }
 
+  setRequiredLeadTimeMs(leadTimeMs: number): void {
+    this.requiredLeadTimeMs = leadTimeMs;
+    this.sendStateUpdate();
+  }
+
+  setMinBufferMs(minBufferMs: number): void {
+    this.minBufferMs = minBufferMs;
+    this.sendStateUpdate();
+  }
+
   // Send state update
   // When skipHardwareRead is true, use stateManager values instead of reading from hardware.
   // This avoids race conditions when responding to volume commands.
@@ -307,6 +327,8 @@ export class ProtocolHandler {
           volume,
           muted,
           static_delay_ms: staticDelayMs,
+          required_lead_time_ms: this.requiredLeadTimeMs,
+          min_buffer_ms: this.minBufferMs,
           supported_commands: ["set_static_delay"],
         },
       },

--- a/src/core/protocol-handler.ts
+++ b/src/core/protocol-handler.ts
@@ -31,6 +31,12 @@ const STATE_UPDATE_INTERVAL = 5000; // 5 seconds
 const DEFAULT_REQUIRED_LEAD_TIME_MS = 250;
 const DEFAULT_MIN_BUFFER_MS = 250;
 
+function assertBufferMs(value: number, name: string): void {
+  if (!isFinite(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative finite number`);
+  }
+}
+
 export interface ProtocolHandlerConfig {
   clientName?: string;
   codecs?: Codec[];
@@ -68,7 +74,9 @@ export class ProtocolHandler {
     this.bufferCapacity = config.bufferCapacity ?? 1024 * 1024 * 5; // 5MB default
     this.requiredLeadTimeMs =
       config.requiredLeadTimeMs ?? DEFAULT_REQUIRED_LEAD_TIME_MS;
+    assertBufferMs(this.requiredLeadTimeMs, "requiredLeadTimeMs");
     this.minBufferMs = config.minBufferMs ?? DEFAULT_MIN_BUFFER_MS;
+    assertBufferMs(this.minBufferMs, "minBufferMs");
     this.useHardwareVolume = config.useHardwareVolume ?? false;
     this.onVolumeCommand = config.onVolumeCommand;
     this.onDelayCommand = config.onDelayCommand;
@@ -295,11 +303,13 @@ export class ProtocolHandler {
   }
 
   setRequiredLeadTimeMs(leadTimeMs: number): void {
+    assertBufferMs(leadTimeMs, "requiredLeadTimeMs");
     this.requiredLeadTimeMs = leadTimeMs;
     this.sendStateUpdate();
   }
 
   setMinBufferMs(minBufferMs: number): void {
+    assertBufferMs(minBufferMs, "minBufferMs");
     this.minBufferMs = minBufferMs;
     this.sendStateUpdate();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,8 @@ export class SendspinPlayer {
         config.bufferCapacity ??
         (outputMode === "media-element" ? 1024 * 1024 * 5 : 1024 * 1024 * 1.5),
       syncDelay,
+      requiredLeadTimeMs: config.requiredLeadTimeMs,
+      minBufferMs: config.minBufferMs,
       useHardwareVolume: config.useHardwareVolume,
       onVolumeCommand: config.onVolumeCommand,
       onDelayCommand: config.onDelayCommand,
@@ -265,7 +267,7 @@ export class SendspinPlayer {
   /**
    * Update the reported startup lead time at runtime (ms). Reported to the
    * server via client/state. Debounce calls to avoid reacting to transient
-   * fluctuations.
+   * fluctuations. Throws RangeError if not a non-negative finite number.
    */
   setRequiredLeadTimeMs(leadTimeMs: number): void {
     this.core.setRequiredLeadTimeMs(leadTimeMs);
@@ -274,7 +276,8 @@ export class SendspinPlayer {
   /**
    * Update the reported minimum ongoing buffer duration at runtime (ms).
    * Reported to the server via client/state. Debounce calls to avoid reacting
-   * to transient fluctuations.
+   * to transient fluctuations. Throws RangeError if not a non-negative finite
+   * number.
    */
   setMinBufferMs(minBufferMs: number): void {
     this.core.setMinBufferMs(minBufferMs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,6 +263,24 @@ export class SendspinPlayer {
   }
 
   /**
+   * Update the reported startup lead time at runtime (ms). Reported to the
+   * server via client/state. Debounce calls to avoid reacting to transient
+   * fluctuations.
+   */
+  setRequiredLeadTimeMs(leadTimeMs: number): void {
+    this.core.setRequiredLeadTimeMs(leadTimeMs);
+  }
+
+  /**
+   * Update the reported minimum ongoing buffer duration at runtime (ms).
+   * Reported to the server via client/state. Debounce calls to avoid reacting
+   * to transient fluctuations.
+   */
+  setMinBufferMs(minBufferMs: number): void {
+    this.core.setMinBufferMs(minBufferMs);
+  }
+
+  /**
    * Set the sync correction mode at runtime.
    */
   setCorrectionMode(mode: CorrectionMode): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,8 @@ export interface ClientState {
       volume: number;
       muted: boolean;
       static_delay_ms: number;
+      required_lead_time_ms: number;
+      min_buffer_ms: number;
       supported_commands?: string[];
     };
   };
@@ -449,6 +451,22 @@ export interface SendspinCoreConfig {
    * Defaults to a browser/platform-specific heuristic value if not provided.
    */
   syncDelay?: number;
+
+  /**
+   * Minimum startup lead time in milliseconds reported to the server via
+   * client/state (codec init, decode warmup, audio backend buffering, DAC).
+   * Can be updated at runtime via setRequiredLeadTimeMs.
+   * Default: 250.
+   */
+  requiredLeadTimeMs?: number;
+
+  /**
+   * Requested minimum ongoing buffer duration in milliseconds reported to the
+   * server via client/state, to absorb network jitter during playback.
+   * Can be updated at runtime via setMinBufferMs.
+   * Default: 250.
+   */
+  minBufferMs?: number;
 
   /**
    * Use hardware/external volume control instead of software gain.


### PR DESCRIPTION
Servers need each player's `required_lead_time_ms` and `min_buffer_ms` to compute per-player send-ahead since https://github.com/Sendspin/spec/pull/69 got merged.
The SDK now makes both of them configurable via `SendspinCoreConfig` (default 250ms each, matches Music Assistants internal default).
Both can also be updated during runtime with `setRequiredLeadTimeMs` / `setMinBufferMs`, matching the spec which allows clients to update these at any time.

The sample player gains inputs for both values, and the README documents the config options and runtime setters.