### PR TITLE
Recorrect on sustained drift

### DIFF
--- a/src/audio/recorrection-monitor.ts
+++ b/src/audio/recorrection-monitor.ts
@@ -132,9 +132,8 @@ export class RecorrectionMonitor {
       nowMs - this.pendingJumpAtMs <= RECORRECTION_TRANSIENT_CONFIRM_WINDOW_MS;
     this.pendingJumpSign = jumpSign;
     this.pendingJumpAtMs = nowMs;
+    // Keep the pending jump so a sustained same-sign run stays confirmed.
     if (isConfirmed) {
-      this.pendingJumpSign = null;
-      this.pendingJumpAtMs = null;
       return false;
     }
 
@@ -157,7 +156,8 @@ export class RecorrectionMonitor {
       return false;
     }
     if (isTransient) {
-      this.clearBreachState();
+      // Reset only the breach timer, keep pending-jump state to confirm next check.
+      this.breachStartedAtMs = null;
       return false;
     }
     if (this.breachStartedAtMs === null) {


### PR DESCRIPTION
The recorrection monitor treated every sync-error jump as transient, re-arming on each check, so a sustained one-directional drift never accumulated the breach time needed to fire a hard resync.

Once a same-sign jump is confirmed, the pending-jump state is now kept rather than cleared, and the transient branch resets only the breach timer. A continuing run of same-sign jumps stays confirmed and a sustained breach can build to a recorrection.