### PR TITLE
Fix spurious resyncs from oscillating sync error

### DIFF
--- a/src/audio/recorrection-monitor.ts
+++ b/src/audio/recorrection-monitor.ts
@@ -117,9 +117,8 @@ export class RecorrectionMonitor {
     }
 
     const jumpDeltaMs = rawSyncErrorMs - prev;
-    const jumpSign = Math.sign(rawSyncErrorMs);
-    const isJumpDetected =
-      Math.abs(jumpDeltaMs) >= RECORRECTION_TRANSIENT_JUMP_MS && jumpSign !== 0;
+    const jumpSign = Math.sign(jumpDeltaMs);
+    const isJumpDetected = Math.abs(jumpDeltaMs) >= RECORRECTION_TRANSIENT_JUMP_MS;
     if (!isJumpDetected) {
       this.pendingJumpSign = null;
       this.pendingJumpAtMs = null;


### PR DESCRIPTION
Transient jump confirmation signed the jump by the current error position (`Math.sign(rawSyncErrorMs)`) instead of the jump direction. When sync error oscillated on one side of zero (e.g. `+50 → +10 → +50`), both jumps read the same sign and got falsely confirmed as sustained drift, releasing transient suppression and triggering an unnecessary hard resync.

Signing by `jumpDeltaMs` confirms only genuine same-direction drift. Spike-and-rebound transients now correctly stay suppressed.

Also drops the now-redundant `jumpSign !== 0` guard, since `abs(jumpDeltaMs) >= 25` already implies a nonzero sign.