### PR TITLE
Reject non-monotonic timestamps in the time filter

### DIFF
--- a/src/core/time-filter.ts
+++ b/src/core/time-filter.ts
@@ -84,8 +84,9 @@ export class SendspinTimeFilter {
    * @param time_added - Client timestamp when this measurement was taken in microseconds
    */
   update(measurement: number, max_error: number, time_added: number): void {
-    if (time_added === this._last_update) {
-      // Skip duplicate timestamps to avoid division by zero in drift calculation
+    if (time_added <= this._last_update) {
+      // Skip non-monotonic timestamps. dt == 0 divides by zero in the drift
+      // calc, dt < 0 corrupts the predict step.
       return;
     }
 
@@ -267,6 +268,7 @@ export class SendspinTimeFilter {
    */
   reset(): void {
     this._count = 0;
+    this._last_update = 0;
     this._offset = 0.0;
     this._drift = 0.0;
     this._offset_covariance = Infinity;


### PR DESCRIPTION
The filter only skipped timestamps equal to the last update, so a backward timestamp produced a negative `dt` that corrupts the Kalman predict step. `update()` now rejects any non-increasing timestamp, and `reset()` clears the stale `_last_update`. Matches the C++ implementation.