### PR TITLE
Keep live stream position advancing

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -346,12 +346,14 @@ export class SendspinCore implements StreamHandler {
       metadata.progress.track_progress +
       (elapsedUs * metadata.progress.playback_speed) / 1_000_000;
 
+    const trackDuration = metadata.progress.track_duration;
     return {
-      positionMs: Math.max(
-        0,
-        Math.min(positionMs, metadata.progress.track_duration),
-      ),
-      durationMs: metadata.progress.track_duration,
+      // track_duration 0 means unbounded (live radio), so floor at 0 only.
+      positionMs:
+        trackDuration === 0
+          ? Math.max(0, positionMs)
+          : Math.max(0, Math.min(positionMs, trackDuration)),
+      durationMs: trackDuration,
       playbackSpeed: metadata.progress.playback_speed / 1000,
     };
   }


### PR DESCRIPTION
The track progress getter clamped `positionMs` to `[0, track_duration]`. For live streams `track_duration` is `0`, so the upper clamp pinned the position to `0` and the counter never advanced.

When `track_duration` is `0` (unbounded, e.g. live radio) the position is now floored at `0` only, with no ceiling.