### PR TITLE
Recorrect through sustained transient jitter

### DIFF
--- a/src/audio/recorrection-monitor.ts
+++ b/src/audio/recorrection-monitor.ts
@@ -23,6 +23,7 @@ export class RecorrectionMonitor {
   private prevRawSyncErrorMs: number | null = null;
   private pendingJumpSign: number | null = null;
   private pendingJumpAtMs: number | null = null;
+  private transientStartedAtMs: number | null = null;
   private _hardResyncGraceUntilMs: number | null = null;
   private _lastHardResyncAtMs: number = -Infinity;
   /** After a recorrection, scheduling must not start before this time. */
@@ -63,6 +64,7 @@ export class RecorrectionMonitor {
     this.breachStartedAtMs = null;
     this.pendingJumpSign = null;
     this.pendingJumpAtMs = null;
+    this.transientStartedAtMs = null;
   }
 
   resetCheckState(): void {
@@ -118,7 +120,8 @@ export class RecorrectionMonitor {
 
     const jumpDeltaMs = rawSyncErrorMs - prev;
     const jumpSign = Math.sign(jumpDeltaMs);
-    const isJumpDetected = Math.abs(jumpDeltaMs) >= RECORRECTION_TRANSIENT_JUMP_MS;
+    const isJumpDetected =
+      Math.abs(jumpDeltaMs) >= RECORRECTION_TRANSIENT_JUMP_MS;
     if (!isJumpDetected) {
       this.pendingJumpSign = null;
       this.pendingJumpAtMs = null;
@@ -155,9 +158,21 @@ export class RecorrectionMonitor {
       return false;
     }
     if (isTransient) {
-      // Reset only the breach timer, keep pending-jump state to confirm next check.
-      this.breachStartedAtMs = null;
-      return false;
+      // Jitter that keeps suppressing for SUSTAIN_MS while smoothed stays high
+      // is sustained drift, not a glitch. Stop treating it as transient.
+      if (this.transientStartedAtMs === null) {
+        this.transientStartedAtMs = nowMs;
+      }
+      if (nowMs - this.transientStartedAtMs < RECORRECTION_SUSTAIN_MS) {
+        this.breachStartedAtMs = null;
+        return false;
+      }
+      // Mature on the same budget as clean drift by counting from suppression start.
+      if (this.breachStartedAtMs === null) {
+        this.breachStartedAtMs = this.transientStartedAtMs;
+      }
+    } else {
+      this.transientStartedAtMs = null;
     }
     if (this.breachStartedAtMs === null) {
       this.breachStartedAtMs = nowMs;


### PR DESCRIPTION
PR #118 signed jumps with `Math.sign(jumpDeltaMs)` to stop oscillation around zero confirming as drift. That over-corrected: oscillation around any nonzero value never confirms either, so a sustained drift whose raw error bounces ≥25ms each check reads as a permanent transient and never fires, even with smoothed pinned at 2× trigger.

This tracks how long suppression has run while smoothed stays high. Past `SUSTAIN_MS`, the `transient` diagnosis is treated as wrong and the breach matures, seeded from when suppression began so jittery drift fires on the same budget as clean drift.