### PR TITLE
Run CI on Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Lint


### PR DESCRIPTION
Node 20 reached end-of-life on 2026-04-30, so the test and release workflows now run on Node 24, the current active LTS. 

This also unblocks #125.