### PR TITLE
Persist server-commanded static delay across restarts

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -22,7 +22,8 @@ const STORAGE_KEYS = {
   PLAYER_ID: "sendspin-player-id",
   VOLUME: "sendspin-volume",
   MUTED: "sendspin-muted",
-  SYNC_DELAY: "sendspin-sync-delay",
+  // Shared with the SDK, which persists the static delay under this key.
+  SYNC_DELAY: "sendspin-static-delay-ms",
   REQUIRED_LEAD_TIME: "sendspin-required-lead-time",
   MIN_BUFFER: "sendspin-min-buffer",
   CORRECTION_MODE: "sendspin-correction-mode",
@@ -578,11 +579,6 @@ async function connect() {
       localStorage.getItem(STORAGE_KEYS.VOLUME) || "80",
       10,
     );
-    const savedSyncDelay = parseInt(
-      localStorage.getItem(STORAGE_KEYS.SYNC_DELAY) || "0",
-      10,
-    );
-    const sanitizedSyncDelay = sanitizeSyncDelay(savedSyncDelay);
     const savedCorrectionMode =
       localStorage.getItem(STORAGE_KEYS.CORRECTION_MODE) || "sync";
 
@@ -601,7 +597,6 @@ async function connect() {
       playerId: getPlayerId(),
       baseUrl: serverUrl,
       clientName: "Sendspin Sample Player",
-      syncDelay: sanitizedSyncDelay,
       requiredLeadTimeMs,
       minBufferMs,
       correctionMode: savedCorrectionMode,
@@ -611,6 +606,10 @@ async function connect() {
           showToast(`Reconnecting (attempt ${attempt})`, "info"),
         onReconnected: () => showToast("Reconnected", "success"),
         onExhausted: () => showToast("Reconnect failed", "error"),
+      },
+      onDelayCommand: (delayMs) => {
+        syncDelayInput.value = delayMs;
+        showToast(`Server set sync delay to ${delayMs}ms`, "info");
       },
       onStateChange,
     });
@@ -724,8 +723,12 @@ function toggleMute() {
 function applySyncDelay() {
   const delay = sanitizeSyncDelay(parseInt(syncDelayInput.value, 10));
   syncDelayInput.value = delay;
-  saveSyncDelay(delay);
-  player.setSyncDelay(delay);
+  if (player) {
+    player.setSyncDelay(delay);
+  } else {
+    // No player yet, so seed the SDK's key for the next connect.
+    saveSyncDelay(delay);
+  }
   showToast(`Sync delay set to ${delay}ms`, "success");
 }
 

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -12,6 +12,7 @@ import { ProtocolHandler } from "./protocol-handler";
 import { StateManager } from "./state-manager";
 import { WebSocketManager } from "./websocket-manager";
 import { SendspinTimeFilter } from "./time-filter";
+import { StaticDelayStore } from "./static-delay-store";
 import { clampSyncDelayMs } from "../sync-delay";
 import type {
   SendspinCoreConfig,
@@ -39,6 +40,7 @@ export class SendspinCore implements StreamHandler {
 
   private config: SendspinCoreConfig;
   private _syncDelayMs: number;
+  private delayStore: StaticDelayStore;
 
   // Stream events — consumers (e.g., SendspinPlayer) subscribe to these
   private _onAudioData?: (chunk: DecodedAudioChunk) => void;
@@ -59,7 +61,13 @@ export class SendspinCore implements StreamHandler {
     const clientName = config.clientName ?? `Sendspin JS Client (${randomId})`;
 
     this.config = { ...config, playerId, clientName };
-    this._syncDelayMs = clampSyncDelayMs(config.syncDelay ?? 0);
+
+    // Initial delay precedence: explicit config, then persisted, then default.
+    this.delayStore = new StaticDelayStore(config.storage ?? null);
+    const persisted = this.delayStore.load();
+    const initialDelay =
+      config.syncDelay ?? persisted ?? config.defaultSyncDelay ?? 0;
+    this._syncDelayMs = clampSyncDelayMs(initialDelay);
 
     this.timeFilter = new SendspinTimeFilter(0, 1.1, 2.0, 1e-12);
     this.stateManager = new StateManager(config.onStateChange);
@@ -127,9 +135,14 @@ export class SendspinCore implements StreamHandler {
     this._onVolumeUpdate?.();
   }
 
-  handleSyncDelayChange(delayMs: number): void {
+  private applyDelay(delayMs: number): void {
     this._syncDelayMs = clampSyncDelayMs(delayMs);
+    this.delayStore.save(this._syncDelayMs);
     this._onSyncDelayChange?.(this._syncDelayMs);
+  }
+
+  handleSyncDelayChange(delayMs: number): void {
+    this.applyDelay(delayMs);
   }
 
   getSyncDelayMs(): number {
@@ -266,8 +279,7 @@ export class SendspinCore implements StreamHandler {
   // ========================================
 
   setSyncDelay(delayMs: number): void {
-    this._syncDelayMs = clampSyncDelayMs(delayMs);
-    this._onSyncDelayChange?.(this._syncDelayMs);
+    this.applyDelay(delayMs);
     this.protocolHandler.sendStateUpdate();
   }
 

--- a/src/core/static-delay-store.ts
+++ b/src/core/static-delay-store.ts
@@ -1,0 +1,35 @@
+/**
+ * Persists the server-commanded static delay so it survives reboots and
+ * reconnections, as the spec requires.
+ */
+
+import type { SendspinStorage } from "../types";
+import { clampSyncDelayMs } from "../sync-delay";
+
+const STATIC_DELAY_STORAGE_KEY = "sendspin-static-delay-ms";
+
+export class StaticDelayStore {
+  constructor(private storage: SendspinStorage | null) {}
+
+  load(): number | null {
+    if (!this.storage) return null;
+    try {
+      const stored = this.storage.getItem(STATIC_DELAY_STORAGE_KEY);
+      if (stored === null) return null;
+      const value = parseFloat(stored);
+      if (isNaN(value)) return null;
+      return clampSyncDelayMs(value);
+    } catch {
+      return null;
+    }
+  }
+
+  save(delayMs: number): void {
+    if (!this.storage) return;
+    try {
+      this.storage.setItem(STATIC_DELAY_STORAGE_KEY, delayMs.toString());
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,9 +94,15 @@ export class SendspinPlayer {
       );
     }
 
-    const syncDelay = config.syncDelay ?? getDefaultSyncDelay();
+    let storage: SendspinStorage | null = null;
+    if (config.storage !== undefined) {
+      storage = config.storage;
+    } else if (typeof localStorage !== "undefined") {
+      storage = localStorage;
+    }
 
-    // Create core (protocol + decoding)
+    // Create core (protocol + decoding). It resolves the effective initial
+    // delay, so read it back below for the scheduler's starting value.
     this.core = new SendspinCore({
       playerId: config.playerId,
       baseUrl: config.baseUrl,
@@ -106,7 +112,9 @@ export class SendspinPlayer {
       bufferCapacity:
         config.bufferCapacity ??
         (outputMode === "media-element" ? 1024 * 1024 * 5 : 1024 * 1024 * 1.5),
-      syncDelay,
+      syncDelay: config.syncDelay,
+      defaultSyncDelay: getDefaultSyncDelay(),
+      storage,
       requiredLeadTimeMs: config.requiredLeadTimeMs,
       minBufferMs: config.minBufferMs,
       useHardwareVolume: config.useHardwareVolume,
@@ -117,14 +125,9 @@ export class SendspinPlayer {
       onStateChange: config.onStateChange,
     });
 
-    // Create scheduler (Web Audio playback)
-    let storage: SendspinStorage | null = null;
-    if (config.storage !== undefined) {
-      storage = config.storage;
-    } else if (typeof localStorage !== "undefined") {
-      storage = localStorage;
-    }
+    const syncDelay = this.core.getSyncDelayMs();
 
+    // Create scheduler (Web Audio playback)
     this.scheduler = new AudioScheduler({
       stateManager: this.core._stateManager,
       timeFilter: this.core._timeFilter,

--- a/src/types.ts
+++ b/src/types.ts
@@ -442,7 +442,8 @@ export interface SendspinCoreConfig {
    * Positive values make playback earlier to compensate for downstream device latency.
    * Allowed range: 0-5000.
    * Runtime update behavior depends on the active correction mode settings.
-   * Defaults to a browser/platform-specific heuristic value if not provided.
+   * Falls back to a persisted value, then `defaultSyncDelay`, then 0.
+   * SendspinPlayer supplies a browser/platform-specific heuristic as that default.
    *
    * Server-commanded delays (set_static_delay) are persisted via `storage` and
    * restored on the next connect. Passing `syncDelay` explicitly overrides any
@@ -459,7 +460,8 @@ export interface SendspinCoreConfig {
 
   /**
    * Storage for persisting SDK state (cached output latency and the
-   * server-commanded static delay). Defaults to localStorage. Pass null to
+   * server-commanded static delay). SendspinCore persists only when this is
+   * provided. SendspinPlayer defaults it to localStorage. Pass null to
    * disable persistence.
    */
   storage?: SendspinStorage | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -329,12 +329,6 @@ export interface SendspinPlayerConfig extends SendspinCoreConfig {
    * Default: true
    */
   useOutputLatencyCompensation?: boolean;
-
-  /**
-   * Storage for persisting SDK state (e.g., cached output latency).
-   * Defaults to localStorage. Pass null to disable persistence.
-   */
-  storage?: SendspinStorage | null;
 }
 
 /**
@@ -449,8 +443,26 @@ export interface SendspinCoreConfig {
    * Allowed range: 0-5000.
    * Runtime update behavior depends on the active correction mode settings.
    * Defaults to a browser/platform-specific heuristic value if not provided.
+   *
+   * Server-commanded delays (set_static_delay) are persisted via `storage` and
+   * restored on the next connect. Passing `syncDelay` explicitly overrides any
+   * persisted value for that connect.
    */
   syncDelay?: number;
+
+  /**
+   * Fallback static delay used when neither `syncDelay` nor a persisted value
+   * is available. SendspinPlayer sets this to a platform-specific heuristic.
+   * @internal
+   */
+  defaultSyncDelay?: number;
+
+  /**
+   * Storage for persisting SDK state (cached output latency and the
+   * server-commanded static delay). Defaults to localStorage. Pass null to
+   * disable persistence.
+   */
+  storage?: SendspinStorage | null;
 
   /**
    * Minimum startup lead time in milliseconds reported to the server via
@@ -487,6 +499,7 @@ export interface SendspinCoreConfig {
   /**
    * Callback when server sends a set_static_delay command.
    * Called with the new static delay in milliseconds (0-5000).
+   * The SDK persists the value via `storage` before invoking this callback.
    */
   onDelayCommand?: (delayMs: number) => void;
 

--- a/tests/unit/core.test.ts
+++ b/tests/unit/core.test.ts
@@ -6,7 +6,20 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { SendspinCore } from "../../src/core/core";
-import type { StreamFormat } from "../../src/types";
+import type { SendspinStorage, StreamFormat } from "../../src/types";
+
+function makeStorage(): SendspinStorage & { data: Map<string, string> } {
+  const data = new Map<string, string>();
+  return {
+    data,
+    getItem: (k) => (data.has(k) ? data.get(k)! : null),
+    setItem: (k, v) => {
+      data.set(k, v);
+    },
+  };
+}
+
+const STATIC_DELAY_KEY = "sendspin-static-delay-ms";
 
 const PCM_FORMAT: StreamFormat = {
   codec: "pcm",
@@ -337,6 +350,59 @@ describe("SendspinCore.setSyncDelay", () => {
       syncDelay: 8000,
     });
     expect(c2.getSyncDelayMs()).toBe(5000);
+  });
+});
+
+describe("SendspinCore static delay persistence", () => {
+  it("persists a server-commanded delay change to storage", () => {
+    const storage = makeStorage();
+    const core = new SendspinCore({
+      baseUrl: "http://h",
+      playerId: "p",
+      storage,
+    });
+
+    core.handleSyncDelayChange(123);
+
+    expect(storage.data.get(STATIC_DELAY_KEY)).toBe("123");
+  });
+
+  it("restores a persisted delay on a fresh core with the same storage", () => {
+    const storage = makeStorage();
+    storage.data.set(STATIC_DELAY_KEY, "321");
+
+    const core = new SendspinCore({
+      baseUrl: "http://h",
+      playerId: "p",
+      storage,
+    });
+
+    expect(core.getSyncDelayMs()).toBe(321);
+  });
+
+  it("lets an explicit config.syncDelay override the persisted value", () => {
+    const storage = makeStorage();
+    storage.data.set(STATIC_DELAY_KEY, "321");
+
+    const core = new SendspinCore({
+      baseUrl: "http://h",
+      playerId: "p",
+      syncDelay: 100,
+      storage,
+    });
+
+    expect(core.getSyncDelayMs()).toBe(100);
+  });
+
+  it("does not throw or persist when storage is disabled", () => {
+    const core = new SendspinCore({
+      baseUrl: "http://h",
+      playerId: "p",
+      storage: null,
+    });
+
+    expect(() => core.handleSyncDelayChange(123)).not.toThrow();
+    expect(core.getSyncDelayMs()).toBe(123);
   });
 });
 


### PR DESCRIPTION
The SDK dropped the server's `set_static_delay` value on restart and reconnect, forcing embedders to re-supply `syncDelay` on every connect. The spec requires the client to persist it locally.

`SendspinCore` now persists the delay via `storage` (defaults to `localStorage`) and restores it on construction. Initial precedence is explicit `syncDelay`, then persisted, then the platform default.

Closes #111