### PR TITLE
Apply perceptual volume curve to playback gain

### DIFF
--- a/src/audio/scheduler.ts
+++ b/src/audio/scheduler.ts
@@ -51,6 +51,12 @@ const SCHEDULE_REFILL_THRESHOLD_FRACTION = 0.5;
 const SCHEDULE_REFILL_MIN_THRESHOLD_SEC = 0.1;
 const SCHEDULE_REFILL_MAX_THRESHOLD_SEC = 5;
 
+const VOLUME_RAMP_TIME_CONSTANT_SEC = 0.015;
+
+export function perceptualGain(volume: number): number {
+  return Math.pow(volume / 100, 1.5);
+}
+
 export interface AudioSchedulerOptions {
   stateManager: StateManager;
   timeFilter: SendspinTimeFilter;
@@ -634,9 +640,18 @@ export class AudioScheduler {
       this.gainNode.gain.value = 1.0;
       return;
     }
-    this.gainNode.gain.value = this.stateManager.muted
+    const target = this.stateManager.muted
       ? 0
-      : this.stateManager.volume / 100;
+      : perceptualGain(this.stateManager.volume);
+    if (this.audioContext) {
+      this.gainNode.gain.setTargetAtTime(
+        target,
+        this.audioContext.currentTime,
+        VOLUME_RAMP_TIME_CONSTANT_SEC,
+      );
+    } else {
+      this.gainNode.gain.value = target;
+    }
   }
 
   measureBufferedPlaybackRunwaySec(): number {

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -72,7 +72,7 @@ class FakeBufferSource {
 class FakeGainNode {
   gain = {
     value: 1.0,
-    setTargetAtTime(target: number) {
+    setTargetAtTime(target: number, _startTime: number, _timeConstant: number) {
       this.value = target;
     },
   };

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -70,7 +70,12 @@ class FakeBufferSource {
 }
 
 class FakeGainNode {
-  gain = { value: 1.0 };
+  gain = {
+    value: 1.0,
+    setTargetAtTime(target: number) {
+      this.value = target;
+    },
+  };
   connect() {}
 }
 
@@ -513,15 +518,29 @@ describe("AudioScheduler empty / no-context edge cases", () => {
 });
 
 describe("AudioScheduler volume", () => {
-  it("maps volume 0-100 to gain 0-1 and applies mute", () => {
+  it("applies the perceptual (volume/100)^1.5 curve to gain", () => {
     const h = setup();
+    const gain = (h.scheduler as any).gainNode;
+
     h.state.volume = 50;
     h.scheduler.updateVolume();
-    const gain = (h.ctx as any) && (h.scheduler as any).gainNode;
-    expect(gain.gain.value).toBeCloseTo(0.5, 6);
+    expect(gain.gain.value).toBeCloseTo(Math.pow(0.5, 1.5), 6);
 
+    h.state.volume = 100;
+    h.scheduler.updateVolume();
+    expect(gain.gain.value).toBeCloseTo(1.0, 6);
+
+    h.state.volume = 0;
+    h.scheduler.updateVolume();
+    expect(gain.gain.value).toBeCloseTo(0, 6);
+  });
+
+  it("maps muted to gain 0 regardless of volume", () => {
+    const h = setup();
+    h.state.volume = 80;
     h.state.muted = true;
     h.scheduler.updateVolume();
+    const gain = (h.scheduler as any).gainNode;
     expect(gain.gain.value).toBe(0);
   });
 


### PR DESCRIPTION
Volume mapped linearly to gain, so the slider felt top heavy and quiet steps were uneven. Gain now follows a perceptual `(volume/100)^1.5` curve and ramps over 15ms via `setTargetAtTime` to noise on changes.

Closes #105