### PR TITLE
Send only changed `client/state` fields after the initial state

### DIFF
--- a/src/core/protocol-handler.ts
+++ b/src/core/protocol-handler.ts
@@ -31,6 +31,19 @@ const STATE_UPDATE_INTERVAL = 5000; // 5 seconds
 const DEFAULT_REQUIRED_LEAD_TIME_MS = 250;
 const DEFAULT_MIN_BUFFER_MS = 250;
 
+type PlayerStatePayload = NonNullable<ClientState["payload"]["player"]>;
+
+// Snapshot of the diffable player fields. supported_commands is static, sent
+// only in the initial full state, so it is not tracked here.
+interface SentPlayerState {
+  state: NonNullable<PlayerStatePayload["state"]>;
+  volume: number;
+  muted: boolean;
+  static_delay_ms: number;
+  required_lead_time_ms: number;
+  min_buffer_ms: number;
+}
+
 function assertBufferMs(value: number, name: string): void {
   if (!isFinite(value) || value < 0) {
     throw new RangeError(`${name} must be a non-negative finite number`);
@@ -60,6 +73,11 @@ export class ProtocolHandler {
   private onDelayCommand?: (delayMs: number) => void;
   private getExternalVolume?: () => { volume: number; muted: boolean };
   private timeSyncManager: TimeSyncManager;
+
+  // Last player payload sent to the current server connection, or null when no
+  // full state has been sent yet. Cleared on (re)connect so the first send is
+  // full again.
+  private lastSentPlayer: SentPlayerState | null = null;
 
   constructor(
     private playerId: string,
@@ -299,6 +317,8 @@ export class ProtocolHandler {
         },
       },
     };
+    // Reset so the first client/state after connect is a full snapshot.
+    this.lastSentPlayer = null;
     this.wsManager.send(hello);
   }
 
@@ -314,7 +334,8 @@ export class ProtocolHandler {
     this.sendStateUpdate();
   }
 
-  // Send state update
+  // Send state update. The first send after a (re)connect is a full snapshot;
+  // later sends are deltas carrying only changed fields, which the server merges.
   // When skipHardwareRead is true, use stateManager values instead of reading from hardware.
   // This avoids race conditions when responding to volume commands.
   sendStateUpdate(skipHardwareRead = false): void {
@@ -329,20 +350,39 @@ export class ProtocolHandler {
     const syncDelayMs = this.streamHandler.getSyncDelayMs();
     const staticDelayMs = clampSyncDelayMs(syncDelayMs);
 
+    const current: SentPlayerState = {
+      state: this.stateManager.playerState,
+      volume,
+      muted,
+      static_delay_ms: staticDelayMs,
+      required_lead_time_ms: this.requiredLeadTimeMs,
+      min_buffer_ms: this.minBufferMs,
+    };
+
+    const last = this.lastSentPlayer;
+    let player: PlayerStatePayload;
+    if (last === null) {
+      // Full state: every field plus the static supported_commands.
+      player = { ...current, supported_commands: ["set_static_delay"] };
+    } else {
+      // Delta: only changed fields.
+      player = {};
+      if (current.state !== last.state) player.state = current.state;
+      if (current.static_delay_ms !== last.static_delay_ms)
+        player.static_delay_ms = current.static_delay_ms;
+      if (current.volume !== last.volume) player.volume = current.volume;
+      if (current.muted !== last.muted) player.muted = current.muted;
+      if (current.required_lead_time_ms !== last.required_lead_time_ms)
+        player.required_lead_time_ms = current.required_lead_time_ms;
+      if (current.min_buffer_ms !== last.min_buffer_ms)
+        player.min_buffer_ms = current.min_buffer_ms;
+    }
+
     const message: ClientState = {
       type: "client/state" as MessageType.CLIENT_STATE,
-      payload: {
-        player: {
-          state: this.stateManager.playerState,
-          volume,
-          muted,
-          static_delay_ms: staticDelayMs,
-          required_lead_time_ms: this.requiredLeadTimeMs,
-          min_buffer_ms: this.minBufferMs,
-          supported_commands: ["set_static_delay"],
-        },
-      },
+      payload: { player },
     };
+    this.lastSentPlayer = current;
     this.wsManager.send(message);
   }
 

--- a/src/core/protocol-handler.ts
+++ b/src/core/protocol-handler.ts
@@ -164,6 +164,7 @@ export class ProtocolHandler {
   private handleServerHello(): void {
     console.log("Sendspin: Connected to server");
     // Per spec: Send initial client/state immediately after server/hello
+    this.lastSentPlayer = null;
     this.sendStateUpdate();
     // Start time synchronization with fixed bursts.
     this.timeSyncManager.startAndSchedule();

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,12 +88,13 @@ export interface ClientState {
   type: MessageType.CLIENT_STATE;
   payload: {
     player?: {
-      state: "synchronized" | "error";
-      volume: number;
-      muted: boolean;
-      static_delay_ms: number;
-      required_lead_time_ms: number;
-      min_buffer_ms: number;
+      // Full initial state includes all fields; deltas include only changed fields.
+      state?: "synchronized" | "error";
+      static_delay_ms?: number;
+      volume?: number;
+      muted?: boolean;
+      required_lead_time_ms?: number;
+      min_buffer_ms?: number;
       supported_commands?: string[];
     };
   };

--- a/tests/unit/protocol-handler.test.ts
+++ b/tests/unit/protocol-handler.test.ts
@@ -342,6 +342,66 @@ describe("ProtocolHandler extra", () => {
     });
   });
 
+  describe("delta client/state (spec: full then changed-only)", () => {
+    const serverHello = () =>
+      msgEvent(JSON.stringify({ type: "server/hello", payload: {} }));
+
+    it("sends the full player payload on the first state after connect", () => {
+      const handler = makeHandler();
+      handler.sendClientHello();
+      handler.handleMessage(serverHello());
+
+      const player = (
+        lastSent(send, "client/state")!.payload as Record<string, unknown>
+      ).player as Record<string, unknown>;
+      expect(player).toMatchObject({
+        state: "synchronized",
+        volume: expect.any(Number),
+        muted: expect.any(Boolean),
+        static_delay_ms: expect.any(Number),
+        required_lead_time_ms: expect.any(Number),
+        min_buffer_ms: expect.any(Number),
+        supported_commands: ["set_static_delay"],
+      });
+    });
+
+    it("sends only the changed field on the next update", () => {
+      const handler = makeHandler();
+      handler.sendClientHello();
+      handler.handleMessage(serverHello());
+      send.mockClear();
+
+      stateManager.volume = 42;
+      handler.sendStateUpdate();
+
+      const player = (
+        lastSent(send, "client/state")!.payload as Record<string, unknown>
+      ).player as Record<string, unknown>;
+      expect(Object.keys(player)).toEqual(["volume"]);
+      expect(player.volume).toBe(42);
+    });
+
+    it("resets to a full payload after a reconnect", () => {
+      const handler = makeHandler();
+      handler.sendClientHello();
+      handler.handleMessage(serverHello());
+      stateManager.volume = 42;
+      handler.sendStateUpdate();
+      send.mockClear();
+
+      // Reconnect: a fresh server has no prior state to merge into.
+      handler.sendClientHello();
+      handler.sendStateUpdate();
+
+      const player = (
+        lastSent(send, "client/state")!.payload as Record<string, unknown>
+      ).player as Record<string, unknown>;
+      expect(player.supported_commands).toEqual(["set_static_delay"]);
+      expect(player.required_lead_time_ms).toBeTypeOf("number");
+      expect(player.min_buffer_ms).toBeTypeOf("number");
+    });
+  });
+
   describe("handleServerCommand volume / mute (spec server/command player object)", () => {
     const cmd = (player: Record<string, unknown>) =>
       msgEvent(JSON.stringify({ type: "server/command", payload: { player } }));

--- a/tests/unit/protocol-handler.test.ts
+++ b/tests/unit/protocol-handler.test.ts
@@ -365,6 +365,29 @@ describe("ProtocolHandler extra", () => {
       });
     });
 
+    it("sends the full player payload when state changes before server hello", () => {
+      const handler = makeHandler();
+      handler.sendClientHello();
+      stateManager.volume = 42;
+      handler.sendStateUpdate();
+      send.mockClear();
+
+      handler.handleMessage(serverHello());
+
+      const player = (
+        lastSent(send, "client/state")!.payload as Record<string, unknown>
+      ).player as Record<string, unknown>;
+      expect(player).toMatchObject({
+        state: "synchronized",
+        volume: 42,
+        muted: expect.any(Boolean),
+        static_delay_ms: expect.any(Number),
+        required_lead_time_ms: expect.any(Number),
+        min_buffer_ms: expect.any(Number),
+        supported_commands: ["set_static_delay"],
+      });
+    });
+
     it("sends only the changed field on the next update", () => {
       const handler = makeHandler();
       handler.sendClientHello();


### PR DESCRIPTION
Every `client/state` previously resent the full player payload. Now the first send after each connect is a full snapshot and later sends are deltas carrying only the changed fields, which the server merges.
This is specifically allowed since https://github.com/Sendspin/spec/pull/101.

Closes #114