### PR TITLE
Default goodbye reason to `restart`

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -246,7 +246,7 @@ export class SendspinCore implements StreamHandler {
     this.stateManager.currentStreamFormat = null;
   }
 
-  disconnect(reason: GoodbyeReason = "shutdown"): void {
+  disconnect(reason: GoodbyeReason = "restart"): void {
     if (this.wsManager.isConnected()) {
       this.protocolHandler.sendGoodbye(reason);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,9 +234,9 @@ export class SendspinPlayer {
 
   /**
    * Disconnect from Sendspin server
-   * @param reason - Optional reason for disconnecting (default: 'shutdown')
+   * @param reason - Optional reason for disconnecting (default: 'restart')
    */
-  disconnect(reason: GoodbyeReason = "shutdown"): void {
+  disconnect(reason: GoodbyeReason = "restart"): void {
     this.cancelPendingDisconnectPlaybackReset();
     this.suppressDisconnectPlaybackReset = true;
 

--- a/tests/unit/core.test.ts
+++ b/tests/unit/core.test.ts
@@ -425,6 +425,29 @@ describe("SendspinCore.disconnect ordering and idempotency", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it("defaults the goodbye reason to restart, but forwards an explicit reason", () => {
+    const core = new SendspinCore({ baseUrl: "http://h", playerId: "p" });
+    const send = spySend(core);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (core as any).wsManager.isConnected = () => true;
+
+    core.disconnect();
+    expect(send).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "client/goodbye",
+        payload: { reason: "restart" },
+      }),
+    );
+
+    core.disconnect("shutdown");
+    expect(send).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "client/goodbye",
+        payload: { reason: "shutdown" },
+      }),
+    );
+  });
+
   it("fires onConnectionClose only via the close handler, not on disconnect()", () => {
     const core = new SendspinCore({ baseUrl: "http://h", playerId: "p" });
     const cb = vi.fn();


### PR DESCRIPTION
A default `disconnect()` previously sent `client/goodbye` reason `shutdown`.
Per spec an unexplained graceful disconnect should imply `restart`, matching the server assumption when no goodbye is sent at all.

Closes #106