### PR TITLE
Make default correction limits inaudible

### DIFF
--- a/src/audio/scheduler.ts
+++ b/src/audio/scheduler.ts
@@ -861,9 +861,9 @@ export class AudioScheduler {
         scheduleTime = playbackTime - syncDelaySec;
         const minScheduleTimeSec = this.recorrectionMonitor.minScheduleTimeSec;
         if (minScheduleTimeSec !== null) {
-          // After a cutover, drop backlog that ends before the kept tail rather
-          // than clamping it forward, so the snap claws back accumulated lateness.
-          if (scheduleTime + chunk.buffer.duration < minScheduleTimeSec) {
+          // After a cutover, drop backlog that ends at or before the kept tail
+          // rather than clamping it forward, so the snap claws back lateness.
+          if (scheduleTime + chunk.buffer.duration <= minScheduleTimeSec) {
             continue;
           }
           scheduleTime = Math.max(scheduleTime, minScheduleTimeSec);

--- a/src/audio/scheduler.ts
+++ b/src/audio/scheduler.ts
@@ -39,7 +39,12 @@ for (let f = 0; f < SAMPLE_CORRECTION_FADE_LEN; f++) {
     ((SAMPLE_CORRECTION_FADE_LEN - f) / (SAMPLE_CORRECTION_FADE_LEN + 1)) *
     SAMPLE_CORRECTION_FADE_STRENGTH;
 }
-const SYNC_ERROR_ALPHA = 0.1;
+// Playback-rate correction tiers, both within the ±0.5% spec cap (inaudible).
+const RATE_CORRECTION_SOFT = 0.003;
+const RATE_CORRECTION_FIRM = 0.005;
+
+// EMA weight for the sync error. Lower smooths clock noise but slows drift response. Exported only for tests.
+export const SYNC_ERROR_ALPHA = 0.05;
 const SCHEDULE_HEADROOM_SEC = 0.2;
 const SCHEDULE_HORIZON_PRECISE_SEC = 20;
 const SCHEDULE_HORIZON_GOOD_SEC = 8;
@@ -856,6 +861,11 @@ export class AudioScheduler {
         scheduleTime = playbackTime - syncDelaySec;
         const minScheduleTimeSec = this.recorrectionMonitor.minScheduleTimeSec;
         if (minScheduleTimeSec !== null) {
+          // After a cutover, drop backlog that ends before the kept tail rather
+          // than clamping it forward, so the snap claws back accumulated lateness.
+          if (scheduleTime + chunk.buffer.duration < minScheduleTimeSec) {
+            continue;
+          }
           scheduleTime = Math.max(scheduleTime, minScheduleTimeSec);
           playbackTime = scheduleTime + syncDelaySec;
         }
@@ -896,8 +906,8 @@ export class AudioScheduler {
             scheduleTime = this.nextScheduleTime;
             playbackRate = Number.isFinite(thresholds.rate2AboveMs)
               ? correctionErrorMs > 0
-                ? 1.02
-                : 0.98
+                ? 1 + RATE_CORRECTION_FIRM
+                : 1 - RATE_CORRECTION_FIRM
               : 1.0;
             this.currentCorrectionMethod =
               playbackRate === 1.0 ? "none" : "rate";
@@ -928,16 +938,16 @@ export class AudioScheduler {
             if (correctionErrorMs > 0) {
               playbackRate =
                 absErrorMs >= thresholds.rate2AboveMs
-                  ? 1.02
+                  ? 1 + RATE_CORRECTION_FIRM
                   : absErrorMs >= thresholds.rate1AboveMs
-                    ? 1.01
+                    ? 1 + RATE_CORRECTION_SOFT
                     : 1.0;
             } else {
               playbackRate =
                 absErrorMs >= thresholds.rate2AboveMs
-                  ? 0.98
+                  ? 1 - RATE_CORRECTION_FIRM
                   : absErrorMs >= thresholds.rate1AboveMs
-                    ? 0.99
+                    ? 1 - RATE_CORRECTION_SOFT
                     : 1.0;
             }
             this.currentCorrectionMethod =

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,7 +252,7 @@ export type Codec = "pcm" | "opus" | "flac";
 
 /**
  * Audio sync correction mode:
- * - "sync": Multi-device sync, may use pitch-changing playback-rate adjustments for faster convergence.
+ * - "sync": Multi-device sync, may use small playback-rate adjustments (capped at ±0.5%, inaudible) for faster convergence.
  * - "quality": No rate changes; uses sample fixes and tighter resyncs, so you get fewer adjustments but occasional jumps. Starts out of sync until the clock converges. Not recommended for bad networks.
  * - "quality-local": Avoids playback-rate changes; may drift vs. group sync and only resyncs as a last resort.
  */
@@ -265,9 +265,9 @@ export type CorrectionMode = "sync" | "quality" | "quality-local";
 export interface CorrectionThresholds {
   /** Hard resync when sync error exceeds this (ms) */
   resyncAboveMs: number;
-  /** Use ±2% playback rate when error exceeds this (ms). Infinity = disabled. */
+  /** Use the firm (±0.5%) playback-rate tier when error exceeds this (ms). Infinity = disabled. */
   rate2AboveMs: number;
-  /** Use ±1% playback rate when error exceeds this (ms). Infinity = disabled. */
+  /** Use the soft (±0.3%) playback-rate tier when error exceeds this (ms). Infinity = disabled. */
   rate1AboveMs: number;
   /** Use sample insertion/deletion when error is below this (ms). 0 = disabled. */
   samplesBelowMs: number;
@@ -295,10 +295,9 @@ export interface SendspinPlayerConfig extends SendspinCoreConfig {
 
   /**
    * Sync correction mode:
-   * - "sync" (default): Corrects out of sync playback using all methods and may use pitch-changing
-   *   playback-rate adjustments for faster convergence.
-   *   Best for multi-device sync but may cause audible pitch shifts, especially just
-   *   after starting of playback.
+   * - "sync" (default): Corrects out of sync playback using all methods, including small
+   *   playback-rate adjustments capped at ±0.5% (inaudible) for faster convergence.
+   *   Best for multi-device sync.
    * - "quality": No playback-rate changes; uses sample fixes and tighter resyncs, so expect fewer adjustments but occasional jumps. Starts out of sync until the clock converges. Not recommended for bad networks.
    * - "quality-local": Avoids playback-rate changes; may drift vs. other players and only resyncs
    *   as a last resort.

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { AudioScheduler } from "../../src/audio/scheduler";
+import { AudioScheduler, SYNC_ERROR_ALPHA } from "../../src/audio/scheduler";
 import { StateManager } from "../../src/core/state-manager";
 import type { DecodedAudioChunk, StreamFormat } from "../../src/types";
 
@@ -353,12 +353,18 @@ describe("AudioScheduler consecutive-chunk continuity", () => {
 });
 
 describe("AudioScheduler drift correction (sync mode)", () => {
-  // The correction branch keys off the EMA-smoothed error (alpha 0.1), seeded
-  // from 0 after the first chunk. So a single correction chunk with raw error R
-  // produces smoothedError = 0.1 * R. We size each offset so 0.1*R lands in the
-  // target band. The first chunk establishes nextPlaybackTime at offset 0; the
-  // offset is then applied for one contiguous second chunk (gap 100ms < 0.1s
-  // threshold, so the in-sync correction branch — not the gap branch — runs).
+  // The correction branch keys off the EMA-smoothed error, seeded from 0 after
+  // the first chunk. So a single correction chunk with raw error R produces
+  // smoothedError = SYNC_ERROR_ALPHA * R. offsetForSmoothedMs sizes the raw
+  // offset to land a target smoothed error in the desired band, independent of
+  // the alpha value. The first chunk establishes nextPlaybackTime at offset 0.
+  // The offset is then applied for one contiguous second chunk (gap 100ms <
+  // 0.1s threshold, so the in-sync correction branch runs, not the gap branch).
+
+  // Raw clientOffset (µs) that yields the given smoothed error (ms) after one chunk.
+  function offsetForSmoothedMs(ms: number): number {
+    return Math.round((ms / SYNC_ERROR_ALPHA) * 1000);
+  }
 
   function primeFirstChunk(h: Harness, base: number) {
     h.scheduler.handleDecodedChunk(makeChunk(base, 0));
@@ -385,8 +391,8 @@ describe("AudioScheduler drift correction (sync mode)", () => {
     const h = setup();
     const base = nowUs();
     primeFirstChunk(h, base);
-    // raw 20ms -> smoothed 2ms, in (deadband 1, samplesBelow 8).
-    correctOnce(h, base, 20_000);
+    // smoothed 2ms, in (deadband 1, samplesBelow 8).
+    correctOnce(h, base, offsetForSmoothedMs(2));
     expect(h.scheduler.syncInfo.correctionMethod).toBe("samples");
     expect([1, -1]).toContain(h.scheduler.syncInfo.samplesAdjusted);
   });
@@ -395,11 +401,23 @@ describe("AudioScheduler drift correction (sync mode)", () => {
     const h = setup();
     const base = nowUs();
     primeFirstChunk(h, base);
-    // raw 300ms -> smoothed 30ms, in (samplesBelow 8, resyncAbove 200).
-    correctOnce(h, base, 300_000);
+    // smoothed 30ms, in (samplesBelow 8, resyncAbove 200).
+    correctOnce(h, base, offsetForSmoothedMs(30));
     expect(h.scheduler.syncInfo.correctionMethod).toBe("rate");
-    expect([0.98, 0.99, 1.01, 1.02]).toContain(
+    expect([0.995, 0.997, 1.003, 1.005]).toContain(
       h.scheduler.syncInfo.playbackRate,
+    );
+  });
+
+  it("keeps the firm rate tier within the ±0.5% spec cap for large sub-resync errors", () => {
+    const h = setup();
+    const base = nowUs();
+    primeFirstChunk(h, base);
+    // smoothed 50ms, above rate2AboveMs (35) and below resync (200).
+    correctOnce(h, base, offsetForSmoothedMs(50));
+    expect(h.scheduler.syncInfo.correctionMethod).toBe("rate");
+    expect(Math.abs(h.scheduler.syncInfo.playbackRate - 1)).toBeLessThanOrEqual(
+      0.005 + 1e-9,
     );
   });
 
@@ -413,9 +431,9 @@ describe("AudioScheduler drift correction (sync mode)", () => {
     // server timestamps contiguous (gap 100ms) so the in-sync resync branch
     // runs, not the gap branch.
     nowMsValue += 2000;
-    // raw error must still clear resyncAbove after smoothing: raw 2500ms ->
-    // smoothed 250ms. (nowUs advanced 2s, so add 2s to the offset to keep raw.)
-    h.tf.clientOffsetUs = 2_000_000 + 2_500_000;
+    // Drive smoothed error to 250ms (> resyncAbove 200). nowUs advanced 2s, so
+    // add 2s to the offset to keep the raw error at the intended magnitude.
+    h.tf.clientOffsetUs = 2_000_000 + offsetForSmoothedMs(250);
     h.scheduler.handleDecodedChunk(makeChunk(base + 100_000, 0));
     h.scheduler.processAudioQueue();
     expect(h.scheduler.syncInfo.correctionMethod).toBe("resync");
@@ -434,6 +452,29 @@ describe("AudioScheduler server-timestamp gap handling", () => {
     h.scheduler.handleDecodedChunk(makeChunk(base + 5_000_000, 0));
     h.scheduler.processAudioQueue();
     expect(h.scheduler.syncInfo.correctionMethod).toBe("resync");
+  });
+});
+
+describe("AudioScheduler cutover backlog handling", () => {
+  it("drops late backlog on a cutover instead of clamping it forward", () => {
+    const h = setup();
+    const base = nowUs();
+    // Schedule 5 contiguous 100ms chunks so several sources are pending.
+    for (let i = 0; i < 5; i++) {
+      h.scheduler.handleDecodedChunk(makeChunk(base + i * 100_000, 0));
+    }
+    h.scheduler.processAudioQueue();
+    expect(h.ctx.startedSources.length).toBeGreaterThanOrEqual(2);
+
+    // A filter correction shifts the mapping so all buffered audio is now ~2s late.
+    h.tf.clientOffsetUs = -2_000_000;
+    const startedBeforeCutover = h.ctx.startedSources.length;
+
+    // A runtime sync-delay change triggers a guarded cutover (sync mode).
+    h.scheduler.setSyncDelay(10);
+
+    // The late backlog is dropped, not re-scheduled at clamped-forward times.
+    expect(h.ctx.startedSources.length - startedBeforeCutover).toBe(0);
   });
 });
 


### PR DESCRIPTION
With the proposed minimum sync standards in Sendspin/spec#104 the default `sync` mode in `sendspin-js` was no longer spec compliant.

This PR tweaks them to follow the spec.
There were two problems before this PR:
- Drift was corrected with up to ±2% playback-rate changes and was therefore audible
- And startup errors could sit at 100-150 ms for tens of seconds because a resync re-anchored its backlog forward instead of dropping it.