### PR TITLE
Add player audio unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ const player = new SendspinPlayer({
   }
 });
 
-// Connect to server
-await player.connect();
+const connectButton = document.querySelector<HTMLButtonElement>('#connect')!;
+connectButton.addEventListener('click', async () => {
+  // Keep this as the first awaited work in the click/tap handler.
+  await player.unlock();
+  await player.connect();
+});
 
 // Local volume control (affects this player only)
 player.setVolume(80);
@@ -64,6 +68,9 @@ player.sendCommand('switch');  // Switch group
 // Disconnect with reason (optional)
 player.disconnect('user_request');
 ```
+
+Call `unlock()` directly from a click or tap handler, before any other awaited
+work, so the browser can initialize or resume audio during the user gesture.
 
 ## Advanced configuration
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ const player = new SendspinPlayer({
   clientName: 'My Player',
   webSocket: ws,
 });
+await player.unlock();
 await player.connect();
 ```
 

--- a/public/app.js
+++ b/public/app.js
@@ -614,6 +614,7 @@ async function connect() {
       onStateChange,
     });
 
+    await player.unlock();
     await player.connect();
 
     // Apply saved volume

--- a/src/audio/scheduler.ts
+++ b/src/audio/scheduler.ts
@@ -593,13 +593,8 @@ export class AudioScheduler {
 
   async resumeAudioContext(): Promise<void> {
     if (this.audioContext && this.audioContext.state === "suspended") {
-      try {
-        await this.audioContext.resume();
-        console.log("Sendspin: AudioContext resumed");
-      } catch (e) {
-        console.warn("Sendspin: Failed to resume AudioContext:", e);
-        return;
-      }
+      await this.audioContext.resume();
+      console.log("Sendspin: AudioContext resumed");
       if (this.audioBufferQueue.length > 0) this.scheduleQueueProcessing();
       if (this.usesRecorrectionMonitor) this.recorrectionMonitor.start();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,9 @@ export class SendspinPlayer {
 
     this.core.onStreamStart = (format, isFormatUpdate) => {
       this.scheduler.initAudioContext();
-      this.scheduler.resumeAudioContext();
+      void this.scheduler.resumeAudioContext().catch((error) => {
+        console.warn("Sendspin: Failed to resume AudioContext:", error);
+      });
       if (!isFormatUpdate) {
         this.scheduler.clearBuffers();
       }
@@ -224,6 +226,15 @@ export class SendspinPlayer {
       },
       runwaySec * 1000 + DISCONNECT_PLAYBACK_RESET_GRACE_MS,
     );
+  }
+
+  /**
+   * Initialize and resume audio playback. Call this directly from a click or
+   * tap handler, before any other await, to satisfy browser autoplay policies.
+   */
+  async unlock(): Promise<void> {
+    this.scheduler.initAudioContext();
+    await this.scheduler.resumeAudioContext();
   }
 
   // Connect to Sendspin server

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -255,7 +255,7 @@ describe("AudioScheduler AudioContext lifecycle", () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
   });
 
-  it("initializes a new running context without resuming it", async () => {
+  it("does not resume a newly initialized context that is already running", async () => {
     const { scheduler } = createScheduler();
 
     expect(lastCtx).toBeNull();

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -87,6 +87,8 @@ class FakeAudioContext {
   outputLatency = 0;
   destination = {};
   startedSources: FakeBufferSource[] = [];
+  resumeCalls = 0;
+  resumeError: Error | null = null;
   // deliberately NO getOutputTimestamp -> clock stays "estimated"
   constructor(opts?: { sampleRate?: number }) {
     this.sampleRate = opts?.sampleRate ?? 48000;
@@ -103,7 +105,9 @@ class FakeAudioContext {
   createMediaStreamDestination() {
     return { stream: {} };
   }
-  resume() {
+  resume(): Promise<void> {
+    this.resumeCalls++;
+    if (this.resumeError) return Promise.reject(this.resumeError);
     this.state = "running";
     return Promise.resolve();
   }
@@ -114,6 +118,7 @@ class FakeAudioContext {
 }
 
 let lastCtx: FakeAudioContext | null = null;
+let audioContextCreateCount = 0;
 
 // ---------------------------------------------------------------------------
 // Controllable time-filter stub
@@ -168,16 +173,19 @@ function makeChunk(
   };
 }
 
-interface Harness {
+interface SchedulerHarness {
   scheduler: AudioScheduler;
   state: StateManager;
   tf: FakeTimeFilter;
+}
+
+interface Harness extends SchedulerHarness {
   ctx: FakeAudioContext;
 }
 
-function setup(
+function createScheduler(
   opts: Partial<ConstructorParameters<typeof AudioScheduler>[0]> = {},
-): Harness {
+): SchedulerHarness {
   const state = new StateManager();
   const tf = new FakeTimeFilter();
   const scheduler = new AudioScheduler({
@@ -191,6 +199,13 @@ function setup(
   });
   // currentStreamFormat drives ctx sample rate
   state.currentStreamFormat = PCM_FORMAT;
+  return { scheduler, state, tf };
+}
+
+function setup(
+  opts: Partial<ConstructorParameters<typeof AudioScheduler>[0]> = {},
+): Harness {
+  const { scheduler, state, tf } = createScheduler(opts);
   scheduler.initAudioContext();
   const ctx = lastCtx!;
   // running state so playback proceeds
@@ -204,9 +219,11 @@ let nowMsValue = 0;
 beforeEach(() => {
   nowMsValue = 5_000_000; // 5000s in ms -> matches serverTime base below
   lastCtx = null;
+  audioContextCreateCount = 0;
   // global Web Audio + browser stubs
   vi.stubGlobal("AudioContext", function (opts?: { sampleRate?: number }) {
     const ctx = new FakeAudioContext(opts);
+    audioContextCreateCount++;
     lastCtx = ctx;
     return ctx;
   });
@@ -232,6 +249,89 @@ afterEach(() => {
 function nowUs(): number {
   return nowMsValue * 1000;
 }
+
+describe("AudioScheduler AudioContext lifecycle", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("initializes a new running context without resuming it", async () => {
+    const { scheduler } = createScheduler();
+
+    expect(lastCtx).toBeNull();
+    scheduler.initAudioContext();
+
+    const ctx = lastCtx!;
+    expect(audioContextCreateCount).toBe(1);
+    expect(ctx.sampleRate).toBe(SAMPLE_RATE);
+    expect(scheduler.getAudioContext()).toBe(ctx);
+
+    await scheduler.resumeAudioContext();
+    expect(ctx.resumeCalls).toBe(0);
+  });
+
+  it("resumes a suspended context", async () => {
+    const h = setup();
+    h.ctx.state = "suspended";
+
+    await expect(h.scheduler.resumeAudioContext()).resolves.toBeUndefined();
+
+    expect(h.ctx.resumeCalls).toBe(1);
+    expect(h.ctx.state).toBe("running");
+  });
+
+  it("leaves an already-running context untouched", async () => {
+    const h = setup();
+
+    await expect(h.scheduler.resumeAudioContext()).resolves.toBeUndefined();
+
+    expect(h.ctx.resumeCalls).toBe(0);
+    expect(h.ctx.state).toBe("running");
+  });
+
+  it("keeps repeated initialization and resume calls idempotent", async () => {
+    const { scheduler } = createScheduler();
+    scheduler.initAudioContext();
+    const ctx = lastCtx!;
+    ctx.state = "suspended";
+
+    scheduler.initAudioContext();
+    await scheduler.resumeAudioContext();
+    await scheduler.resumeAudioContext();
+
+    expect(audioContextCreateCount).toBe(1);
+    expect(ctx.resumeCalls).toBe(1);
+    expect(ctx.state).toBe("running");
+  });
+
+  it("creates a new context after close", () => {
+    const { scheduler } = createScheduler();
+    scheduler.initAudioContext();
+    const firstCtx = lastCtx;
+
+    scheduler.close();
+    scheduler.initAudioContext();
+
+    expect(audioContextCreateCount).toBe(2);
+    expect(lastCtx).not.toBe(firstCtx);
+  });
+
+  it("propagates resume failures and allows retrying", async () => {
+    const h = setup();
+    const resumeError = new Error("resume blocked");
+    h.ctx.state = "suspended";
+    h.ctx.resumeError = resumeError;
+
+    await expect(h.scheduler.resumeAudioContext()).rejects.toBe(resumeError);
+    expect(h.ctx.resumeCalls).toBe(1);
+    expect(h.ctx.state).toBe("suspended");
+
+    h.ctx.resumeError = null;
+    await expect(h.scheduler.resumeAudioContext()).resolves.toBeUndefined();
+    expect(h.ctx.resumeCalls).toBe(2);
+    expect(h.ctx.state).toBe("running");
+  });
+});
 
 describe("AudioScheduler scheduling math", () => {
   it("first chunk schedules at ctxTime + headroom when chunk client time == now", () => {


### PR DESCRIPTION
Browser audio must start from a user action to play reliably across browsers.

- add `SendspinPlayer.unlock()` for click and tap handlers
- surface audio resume failures to callers
- document usage and cover audio context lifecycle states