### PR TITLE
Defer client state until `server/hello` was received

### DIFF
--- a/src/core/protocol-handler.ts
+++ b/src/core/protocol-handler.ts
@@ -166,7 +166,6 @@ export class ProtocolHandler {
     console.log("Sendspin: Connected to server");
     // Per spec: Send initial client/state immediately after server/hello
     this.hasReceivedServerHello = true;
-    this.lastSentPlayer = null;
     this.sendStateUpdate();
     // Start time synchronization with fixed bursts.
     this.timeSyncManager.startAndSchedule();

--- a/src/core/protocol-handler.ts
+++ b/src/core/protocol-handler.ts
@@ -73,6 +73,7 @@ export class ProtocolHandler {
   private onDelayCommand?: (delayMs: number) => void;
   private getExternalVolume?: () => { volume: number; muted: boolean };
   private timeSyncManager: TimeSyncManager;
+  private hasReceivedServerHello = false;
 
   // Last player payload sent to the current server connection, or null when no
   // full state has been sent yet. Cleared on (re)connect so the first send is
@@ -164,6 +165,7 @@ export class ProtocolHandler {
   private handleServerHello(): void {
     console.log("Sendspin: Connected to server");
     // Per spec: Send initial client/state immediately after server/hello
+    this.hasReceivedServerHello = true;
     this.lastSentPlayer = null;
     this.sendStateUpdate();
     // Start time synchronization with fixed bursts.
@@ -319,6 +321,7 @@ export class ProtocolHandler {
       },
     };
     // Reset so the first client/state after connect is a full snapshot.
+    this.hasReceivedServerHello = false;
     this.lastSentPlayer = null;
     this.wsManager.send(hello);
   }
@@ -340,6 +343,8 @@ export class ProtocolHandler {
   // When skipHardwareRead is true, use stateManager values instead of reading from hardware.
   // This avoids race conditions when responding to volume commands.
   sendStateUpdate(skipHardwareRead = false): void {
+    if (!this.hasReceivedServerHello) return;
+
     let volume = this.stateManager.volume;
     let muted = this.stateManager.muted;
     if (!skipHardwareRead && this.useHardwareVolume && this.getExternalVolume) {

--- a/tests/unit/core.test.ts
+++ b/tests/unit/core.test.ts
@@ -35,6 +35,17 @@ function spySend(core: SendspinCore): ReturnType<typeof vi.fn> {
   return send;
 }
 
+function completeHandshake(
+  core: SendspinCore,
+  send: ReturnType<typeof vi.fn>,
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (core as any).protocolHandler.handleMessage({
+    data: JSON.stringify({ type: "server/hello", payload: {} }),
+  } as MessageEvent);
+  send.mockClear();
+}
+
 function seedMetadata(
   core: SendspinCore,
   timestampUs: number,
@@ -285,6 +296,10 @@ describe("SendspinCore command + state forwarding", () => {
     core = new SendspinCore({ baseUrl: "http://h", playerId: "p" });
   });
 
+  afterEach(() => {
+    core._stateManager.clearAllIntervals();
+  });
+
   it("forwards a controller command with command name and params merged", () => {
     const send = spySend(core);
     core.sendCommand("volume", { volume: 42 });
@@ -297,16 +312,18 @@ describe("SendspinCore command + state forwarding", () => {
 
   it("setVolume clamps in state manager and sends a client/state update", () => {
     const send = spySend(core);
-    core.setVolume(150);
+    completeHandshake(core, send);
+    core.setVolume(-10);
 
-    expect(core.volume).toBe(100); // clamped 0-100
+    expect(core.volume).toBe(0); // clamped 0-100
     expect(send).toHaveBeenCalledTimes(1);
     expect(send.mock.calls[0][0].type).toBe("client/state");
-    expect(send.mock.calls[0][0].payload.player.volume).toBe(100);
+    expect(send.mock.calls[0][0].payload.player.volume).toBe(0);
   });
 
   it("setMuted updates state and sends a client/state update", () => {
     const send = spySend(core);
+    completeHandshake(core, send);
     core.setMuted(true);
 
     expect(core.muted).toBe(true);
@@ -330,10 +347,15 @@ describe("SendspinCore.setSyncDelay", () => {
     core = new SendspinCore({ baseUrl: "http://h", playerId: "p" });
   });
 
+  afterEach(() => {
+    core._stateManager.clearAllIntervals();
+  });
+
   it("clamps the delay, updates getSyncDelayMs, fires callback, and sends state", () => {
     const cb = vi.fn();
     core.onSyncDelayChange = cb;
     const send = spySend(core);
+    completeHandshake(core, send);
 
     core.setSyncDelay(99999); // clamp to 5000
 

--- a/tests/unit/protocol-handler.test.ts
+++ b/tests/unit/protocol-handler.test.ts
@@ -182,6 +182,18 @@ describe("ProtocolHandler extra", () => {
     );
   }
 
+  const serverHello = () =>
+    msgEvent(JSON.stringify({ type: "server/hello", payload: {} }));
+
+  function makeReadyHandler(
+    config: ConstructorParameters<typeof ProtocolHandler>[5] = {},
+  ): ProtocolHandler {
+    const handler = makeHandler(config);
+    handler.handleMessage(serverHello());
+    send.mockClear();
+    return handler;
+  }
+
   beforeEach(() => {
     vi.useFakeTimers();
     send = vi.fn();
@@ -255,7 +267,7 @@ describe("ProtocolHandler extra", () => {
     it("reports volume in 0-100 and the player operational state", () => {
       const handler = makeHandler();
       stateManager.volume = 42;
-      handler.sendStateUpdate();
+      handler.handleMessage(serverHello());
 
       const state = lastSent(send, "client/state")!;
       const player = (state.payload as Record<string, unknown>)
@@ -268,7 +280,7 @@ describe("ProtocolHandler extra", () => {
     it("includes static_delay_ms clamped to 0-5000", () => {
       streamHandler = makeStreamHandlerWithDelay(9999);
       const handler = makeHandler();
-      handler.sendStateUpdate();
+      handler.handleMessage(serverHello());
 
       const player = (
         lastSent(send, "client/state")!.payload as Record<string, unknown>
@@ -278,7 +290,7 @@ describe("ProtocolHandler extra", () => {
 
     it("declares set_static_delay in player supported_commands", () => {
       const handler = makeHandler();
-      handler.sendStateUpdate();
+      handler.handleMessage(serverHello());
       const player = (
         lastSent(send, "client/state")!.payload as Record<string, unknown>
       ).player as Record<string, unknown>;
@@ -287,7 +299,7 @@ describe("ProtocolHandler extra", () => {
 
     it("includes required_lead_time_ms (spec: always required for players)", () => {
       const handler = makeHandler();
-      handler.sendStateUpdate();
+      handler.handleMessage(serverHello());
       const player = (
         lastSent(send, "client/state")!.payload as Record<string, unknown>
       ).player as Record<string, unknown>;
@@ -296,7 +308,7 @@ describe("ProtocolHandler extra", () => {
 
     it("includes min_buffer_ms (spec: always required for players)", () => {
       const handler = makeHandler();
-      handler.sendStateUpdate();
+      handler.handleMessage(serverHello());
       const player = (
         lastSent(send, "client/state")!.payload as Record<string, unknown>
       ).player as Record<string, unknown>;
@@ -310,8 +322,7 @@ describe("ProtocolHandler extra", () => {
           useHardwareVolume: true,
           getExternalVolume,
         });
-        // stateManager would say 100/false; hardware says 30/true.
-        handler.sendStateUpdate();
+        handler.handleMessage(serverHello());
 
         const player = (
           lastSent(send, "client/state")!.payload as Record<string, unknown>
@@ -323,11 +334,12 @@ describe("ProtocolHandler extra", () => {
 
       it("skips the hardware read and uses stateManager values when skipHardwareRead", () => {
         const getExternalVolume = vi.fn(() => ({ volume: 30, muted: true }));
-        const handler = makeHandler({
+        const handler = makeReadyHandler({
           useHardwareVolume: true,
           getExternalVolume,
         });
         stateManager.volume = 77;
+        getExternalVolume.mockClear();
         send.mockClear();
 
         handler.sendStateUpdate(true);
@@ -343,9 +355,6 @@ describe("ProtocolHandler extra", () => {
   });
 
   describe("delta client/state (spec: full then changed-only)", () => {
-    const serverHello = () =>
-      msgEvent(JSON.stringify({ type: "server/hello", payload: {} }));
-
     it("sends the full player payload on the first state after connect", () => {
       const handler = makeHandler();
       handler.sendClientHello();
@@ -388,6 +397,16 @@ describe("ProtocolHandler extra", () => {
       });
     });
 
+    it("does not send client/state before server hello", () => {
+      const handler = makeHandler();
+      handler.sendClientHello();
+
+      stateManager.volume = 42;
+      handler.sendStateUpdate();
+
+      expect(lastSent(send, "client/state")).toBeUndefined();
+    });
+
     it("sends only the changed field on the next update", () => {
       const handler = makeHandler();
       handler.sendClientHello();
@@ -415,6 +434,7 @@ describe("ProtocolHandler extra", () => {
       // Reconnect: a fresh server has no prior state to merge into.
       handler.sendClientHello();
       handler.sendStateUpdate();
+      handler.handleMessage(serverHello());
 
       const player = (
         lastSent(send, "client/state")!.payload as Record<string, unknown>
@@ -452,8 +472,7 @@ describe("ProtocolHandler extra", () => {
     });
 
     it("sends a follow-up client/state reflecting the commanded volume", () => {
-      const handler = makeHandler();
-      send.mockClear();
+      const handler = makeReadyHandler();
       handler.handleMessage(cmd({ command: "volume", volume: 33 }));
       const player = (
         lastSent(send, "client/state")!.payload as Record<string, unknown>
@@ -490,8 +509,7 @@ describe("ProtocolHandler extra", () => {
     });
 
     it("sends a client/state after ending the player stream", () => {
-      const handler = makeHandler();
-      send.mockClear();
+      const handler = makeReadyHandler();
       handler.handleMessage(end({}));
       expect(lastSent(send, "client/state")).toBeDefined();
     });


### PR DESCRIPTION
Prevent `client/state` messages from being sent before the server handshake completes. Local changes made during the handshake are included in the initial full state after `server/hello`.