### PR TITLE
Buffer more audio ahead when streaming FLAC

### DIFF
--- a/src/core/codec-support.ts
+++ b/src/core/codec-support.ts
@@ -1,5 +1,25 @@
 import type { Codec, SupportedFormat } from "../types";
 
+// Depth of buffered audio the server streams ahead, in seconds. Servers gate
+// the send queue on both bytes (buffer_capacity) and duration; aiosendspin's
+// duration horizon is 30s. Sizing the advertised byte capacity below that depth
+// makes bytes the binding limit and starves the buffer on high-rate codecs.
+const BUFFER_DEPTH_SECONDS = 30;
+
+// Cushion on top of the computed worst case so short-term rate spikes (dense
+// passages encode above the track average) never make bytes bind first.
+const BUFFER_CAPACITY_HEADROOM = 1.1;
+
+// FLAC falls back to verbatim frames on incompressible audio, where the frame
+// headers put the stream slightly above raw PCM. Measured at 195.4 kB/s for
+// 48kHz/16-bit stereo (192.0 kB/s raw) with full-scale decorrelated noise.
+const FLAC_WORST_CASE_EXPANSION = 1.02;
+
+// libopus tops out at 512 kbps for stereo. Servers pick their own bitrate
+// (aiosendspin uses the libopus default, ~96 kbps), so assume the ceiling
+// rather than tying the capacity to any one server's encoder settings.
+const OPUS_MAX_BYTES_PER_SECOND = 64_000;
+
 /** Detect which audio codecs the current browser supports. */
 export function getBrowserSupportedCodecs(): Set<Codec> {
   const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
@@ -73,4 +93,38 @@ export function getSupportedFormats(codecs: Codec[]): SupportedFormat[] {
   }
 
   return formats;
+}
+
+/** Worst-case wire byte rate for a single advertised format. */
+function getWireByteRate(format: SupportedFormat): number {
+  const pcmByteRate =
+    format.sample_rate * format.channels * Math.ceil(format.bit_depth / 8);
+
+  switch (format.codec) {
+    case "opus":
+      return OPUS_MAX_BYTES_PER_SECOND;
+    case "flac":
+      return pcmByteRate * FLAC_WORST_CASE_EXPANSION;
+    default:
+      return pcmByteRate;
+  }
+}
+
+/**
+ * Buffer capacity to advertise for a set of supported formats, in bytes.
+ *
+ * The server picks one of the advertised formats, so the capacity is sized for
+ * the highest byte rate among them: enough for the full stream-ahead depth even
+ * on incompressible FLAC. Over-advertising is harmless — the server's duration
+ * horizon still caps how much audio is buffered — while under-advertising costs
+ * buffer depth and, with it, resilience to network stalls.
+ *
+ * :param formats: Formats advertised in `client/hello`, as returned by
+ *     `getSupportedFormats`.
+ */
+export function getDefaultBufferCapacity(formats: SupportedFormat[]): number {
+  const worstByteRate = Math.max(...formats.map(getWireByteRate));
+  return Math.ceil(
+    worstByteRate * BUFFER_DEPTH_SECONDS * BUFFER_CAPACITY_HEADROOM,
+  );
 }

--- a/src/core/codec-support.ts
+++ b/src/core/codec-support.ts
@@ -6,10 +6,6 @@ import type { Codec, SupportedFormat } from "../types";
 // makes bytes the binding limit and starves the buffer on high-rate codecs.
 const BUFFER_DEPTH_SECONDS = 30;
 
-// Cushion on top of the computed worst case so short-term rate spikes (dense
-// passages encode above the track average) never make bytes bind first.
-const BUFFER_CAPACITY_HEADROOM = 1.1;
-
 // FLAC falls back to verbatim frames on incompressible audio, where the frame
 // headers put the stream slightly above raw PCM. Measured at 195.4 kB/s for
 // 48kHz/16-bit stereo (192.0 kB/s raw) with full-scale decorrelated noise.
@@ -115,15 +111,12 @@ function getWireByteRate(format: SupportedFormat): number {
  *
  * The server picks one of the advertised formats, so the capacity is sized for
  * the highest byte rate among them: enough for the full stream-ahead depth even
- * on incompressible FLAC. Over-advertising is harmless — the server's duration
- * horizon still caps how much audio is buffered — while under-advertising costs
- * buffer depth and, with it, resilience to network stalls.
+ * on incompressible FLAC without making bytes the binding limit before the
+ * server's duration horizon.
  *
  * @param formats - Formats advertised in `client/hello`, as returned by `getSupportedFormats`
  */
 export function getDefaultBufferCapacity(formats: SupportedFormat[]): number {
   const worstByteRate = Math.max(...formats.map(getWireByteRate));
-  return Math.ceil(
-    worstByteRate * BUFFER_DEPTH_SECONDS * BUFFER_CAPACITY_HEADROOM,
-  );
+  return Math.ceil(worstByteRate * BUFFER_DEPTH_SECONDS);
 }

--- a/src/core/codec-support.ts
+++ b/src/core/codec-support.ts
@@ -119,8 +119,7 @@ function getWireByteRate(format: SupportedFormat): number {
  * horizon still caps how much audio is buffered — while under-advertising costs
  * buffer depth and, with it, resilience to network stalls.
  *
- * :param formats: Formats advertised in `client/hello`, as returned by
- *     `getSupportedFormats`.
+ * @param formats - Formats advertised in `client/hello`, as returned by `getSupportedFormats`
  */
 export function getDefaultBufferCapacity(formats: SupportedFormat[]): number {
   const worstByteRate = Math.max(...formats.map(getWireByteRate));

--- a/src/core/protocol-handler.ts
+++ b/src/core/protocol-handler.ts
@@ -22,7 +22,7 @@ import type { StreamHandler } from "../internal-types";
 import type { StateManager } from "./state-manager";
 import type { WebSocketManager } from "./websocket-manager";
 import { TimeSyncManager } from "./time-sync-manager";
-import { getSupportedFormats } from "./codec-support";
+import { getDefaultBufferCapacity, getSupportedFormats } from "./codec-support";
 import { clampSyncDelayMs } from "../sync-delay";
 
 // Constants
@@ -52,7 +52,7 @@ export interface ProtocolHandlerConfig {
 export class ProtocolHandler {
   private clientName: string;
   private codecs: Codec[];
-  private bufferCapacity: number;
+  private bufferCapacity: number | undefined;
   private requiredLeadTimeMs: number;
   private minBufferMs: number;
   private useHardwareVolume: boolean;
@@ -71,7 +71,9 @@ export class ProtocolHandler {
   ) {
     this.clientName = config.clientName ?? "Sendspin Player";
     this.codecs = config.codecs ?? ["opus", "flac", "pcm"];
-    this.bufferCapacity = config.bufferCapacity ?? 1024 * 1024 * 5; // 5MB default
+    // Left undefined so the capacity is derived from the formats actually
+    // advertised in client/hello (see sendClientHello).
+    this.bufferCapacity = config.bufferCapacity;
     this.requiredLeadTimeMs =
       config.requiredLeadTimeMs ?? DEFAULT_REQUIRED_LEAD_TIME_MS;
     assertBufferMs(this.requiredLeadTimeMs, "requiredLeadTimeMs");
@@ -277,6 +279,7 @@ export class ProtocolHandler {
 
   // Send client hello with player identification
   sendClientHello(): void {
+    const supportedFormats = getSupportedFormats(this.codecs);
     const hello: ClientHello = {
       type: "client/hello" as MessageType.CLIENT_HELLO,
       payload: {
@@ -293,8 +296,9 @@ export class ProtocolHandler {
             "Unknown",
         },
         "player@v1_support": {
-          supported_formats: getSupportedFormats(this.codecs),
-          buffer_capacity: this.bufferCapacity,
+          supported_formats: supportedFormats,
+          buffer_capacity:
+            this.bufferCapacity ?? getDefaultBufferCapacity(supportedFormats),
           supported_commands: ["volume", "mute"],
         },
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,9 +109,7 @@ export class SendspinPlayer {
       clientName: config.clientName,
       webSocket: config.webSocket,
       codecs: config.codecs,
-      bufferCapacity:
-        config.bufferCapacity ??
-        (outputMode === "media-element" ? 1024 * 1024 * 5 : 1024 * 1024 * 1.5),
+      bufferCapacity: config.bufferCapacity,
       syncDelay: config.syncDelay,
       defaultSyncDelay: getDefaultSyncDelay(),
       storage,

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,7 +428,7 @@ export interface SendspinCoreConfig {
    * not-yet-played encoded audio it may send ahead.
    *
    * Defaults to the server's stream-ahead depth at the worst-case byte rate of
-   * the negotiable formats: ~6.5MB when FLAC or PCM is offered, ~2.1MB for
+   * the negotiable formats: ~5.9MB when FLAC or PCM is offered, ~1.9MB for
    * Opus-only. Set this only for clients with a real, smaller buffer.
    */
   bufferCapacity?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -425,7 +425,7 @@ export interface SendspinCoreConfig {
 
   /**
    * Buffer capacity in bytes, advertised to the server as the amount of
-   * not-yet-played compressed audio it may send ahead.
+   * not-yet-played encoded audio it may send ahead.
    *
    * Defaults to the server's stream-ahead depth at the worst-case byte rate of
    * the negotiable formats: ~6.5MB when FLAC or PCM is offered, ~2.1MB for

--- a/src/types.ts
+++ b/src/types.ts
@@ -424,7 +424,12 @@ export interface SendspinCoreConfig {
   codecs?: Codec[];
 
   /**
-   * Buffer capacity in bytes. Defaults to 5MB for media-element, 1.5MB for direct.
+   * Buffer capacity in bytes, advertised to the server as the amount of
+   * not-yet-played compressed audio it may send ahead.
+   *
+   * Defaults to the server's stream-ahead depth at the worst-case byte rate of
+   * the negotiable formats: ~6.5MB when FLAC or PCM is offered, ~2.1MB for
+   * Opus-only. Set this only for clients with a real, smaller buffer.
    */
   bufferCapacity?: number;
 

--- a/tests/unit/codec-support.test.ts
+++ b/tests/unit/codec-support.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   getBrowserSupportedCodecs,
+  getDefaultBufferCapacity,
   getSupportedFormats,
 } from "../../src/core/codec-support";
 import type { Codec } from "../../src/types";
@@ -148,5 +149,43 @@ describe("getSupportedFormats", () => {
     // Firefox does not support opus; requesting only opus leaves nothing.
     setEnv({ userAgent: UA.firefox, hasAudioDecoder: true });
     expect(() => getSupportedFormats(["opus"])).toThrow(/No supported codecs/);
+  });
+});
+
+describe("getDefaultBufferCapacity", () => {
+  // Server-side stream-ahead depth the advertised capacity has to cover.
+  const DEPTH_SECONDS = 30;
+
+  it("covers the stream-ahead depth of incompressible FLAC", () => {
+    setEnv({ userAgent: UA.chrome, hasAudioDecoder: true });
+    const capacity = getDefaultBufferCapacity(getSupportedFormats(["flac"]));
+    // FLAC on incompressible audio sits just above raw PCM: 48kHz stereo
+    // 16-bit is 192 kB/s, measured at 195.4 kB/s through the server encoder.
+    expect(capacity).toBeGreaterThanOrEqual(195_400 * DEPTH_SECONDS);
+  });
+
+  it("covers PCM at its exact byte rate", () => {
+    setEnv({ userAgent: UA.chrome, hasAudioDecoder: true });
+    const capacity = getDefaultBufferCapacity(getSupportedFormats(["pcm"]));
+    expect(capacity).toBeGreaterThanOrEqual(48000 * 2 * 2 * DEPTH_SECONDS);
+  });
+
+  it("sizes for the highest byte rate among the advertised formats", () => {
+    setEnv({ userAgent: UA.chrome, hasAudioDecoder: true });
+    const opusOnly = getDefaultBufferCapacity(getSupportedFormats(["opus"]));
+    const withFlac = getDefaultBufferCapacity(
+      getSupportedFormats(["opus", "flac"]),
+    );
+    expect(withFlac).toBeGreaterThan(opusOnly);
+    expect(withFlac).toBe(
+      getDefaultBufferCapacity(getSupportedFormats(["flac"])),
+    );
+  });
+
+  it("stays well above the stream-ahead depth for Opus", () => {
+    setEnv({ userAgent: UA.chrome, hasAudioDecoder: true });
+    const capacity = getDefaultBufferCapacity(getSupportedFormats(["opus"]));
+    // ~96 kbps in practice, so the depth covered is far beyond 30s.
+    expect(capacity / (96_000 / 8)).toBeGreaterThan(DEPTH_SECONDS);
   });
 });

--- a/tests/unit/protocol-handler.test.ts
+++ b/tests/unit/protocol-handler.test.ts
@@ -229,6 +229,29 @@ describe("ProtocolHandler extra", () => {
         bit_depth: expect.any(Number),
       });
     });
+
+    it("advertises a buffer capacity covering the stream-ahead depth", () => {
+      const handler = makeHandler({ codecs: ["pcm"] });
+      handler.sendClientHello();
+
+      const support = (
+        lastSent(send, "client/hello")!.payload as Record<string, unknown>
+      )["player@v1_support"] as Record<string, unknown>;
+      // 30s of 48kHz/16-bit stereo PCM, the worst case among the pcm formats.
+      expect(support.buffer_capacity as number).toBeGreaterThanOrEqual(
+        48000 * 2 * 2 * 30,
+      );
+    });
+
+    it("uses an explicit buffer capacity when configured", () => {
+      const handler = makeHandler({ codecs: ["pcm"], bufferCapacity: 123_456 });
+      handler.sendClientHello();
+
+      const support = (
+        lastSent(send, "client/hello")!.payload as Record<string, unknown>
+      )["player@v1_support"] as Record<string, unknown>;
+      expect(support.buffer_capacity).toBe(123_456);
+    });
   });
 
   describe("handleServerHello", () => {


### PR DESCRIPTION
The web player told the server how much audio it could hold based on its output mode, which says nothing about how much data the audio actually takes up. With FLAC that worked out to about 12 seconds of buffer instead of the 30 seconds the server wants to send ahead, making playback more sensitive to network hiccups than it should be.

FLAC is not a rare case: browsers fall back to it whenever Music Assistant is reached over plain http:// on the local network, and Firefox always uses it.

- Buffer size is now calculated from the audio formats the player offers, so it covers the full send-ahead window for any codec
- Around 6.5 MB when FLAC or PCM can be used, ~2.1 MB for Opus-only players
- Mobile players benefit too — their 5 MB was also short on hard-to-compress music
- Buffer size can still be set explicitly for devices with a real, smaller buffer