### PR TITLE
Remove a fixed 200ms delay from audio scheduling

### DIFF
--- a/src/audio/clock-source.ts
+++ b/src/audio/clock-source.ts
@@ -6,6 +6,14 @@
  * - "timestamp": AudioContext.getOutputTimestamp() with extensive validation
  *
  * Promotes to "timestamp" after enough good samples, demotes on failures.
+ *
+ * Both sources report the same quantity: the *render* clock, in the
+ * `AudioContext.currentTime` domain that `source.start()` accepts.
+ * `getOutputTimestamp().contextTime` is the playout clock instead (the frame
+ * leaving the output port), which trails the render clock by
+ * baseLatency + outputLatency, so callers pass that latency in and it is added
+ * back. Without it the two sources would disagree by one output latency and
+ * playback would audibly step whenever the source is promoted or demoted.
  */
 
 type AudioClockSource = "estimated" | "timestamp" | "raw";
@@ -170,6 +178,7 @@ export class ClockSource {
   private getTimestampDerivedTime(
     rawTimeSec: number,
     audioContext: AudioContext,
+    playoutLatencySec: number,
   ): number | null {
     // On Cast receivers, stay on the estimated clock to avoid rate oscillations.
     if (this._timestampPromotionDisabled) {
@@ -213,7 +222,10 @@ export class ClockSource {
       }
 
       const freshnessMs = Math.max(0, rawFreshnessMs);
-      const predictedAudioTimeSec = ts.contextTime + freshnessMs / 1000;
+      // contextTime is the playout clock; lift it into the render-clock domain
+      // so it is directly comparable to (and interchangeable with) currentTime.
+      const predictedAudioTimeSec =
+        ts.contextTime + freshnessMs / 1000 + playoutLatencySec;
       const sample: OutputTimestampSample = {
         contextTimeSec: ts.contextTime,
         performanceTimeMs: ts.performanceTime,
@@ -329,8 +341,19 @@ export class ClockSource {
     }
   }
 
-  /** Get a timing snapshot with both derived and raw AudioContext times. */
-  getTimingSnapshot(audioContext: AudioContext | null): TimingSnapshot {
+  /**
+   * Get a timing snapshot with both derived and raw AudioContext times.
+   *
+   * @param playoutLatencySec Measured baseLatency + outputLatency, used to
+   *   normalize the getOutputTimestamp-derived clock into the render-clock
+   *   domain. Pass the measured value regardless of whether latency
+   *   compensation is enabled: this only keeps the two clock sources in one
+   *   domain, it does not compensate playback.
+   */
+  getTimingSnapshot(
+    audioContext: AudioContext | null,
+    playoutLatencySec = 0,
+  ): TimingSnapshot {
     const nowMs = performance.now();
     const nowUs = nowMs * 1000;
     if (!audioContext) {
@@ -347,6 +370,7 @@ export class ClockSource {
     const timestampTimeSec = this.getTimestampDerivedTime(
       rawTimeSec,
       audioContext,
+      playoutLatencySec,
     );
 
     let derivedTimeSec =

--- a/src/audio/output-latency-tracker.ts
+++ b/src/audio/output-latency-tracker.ts
@@ -4,9 +4,23 @@
  * Tracks AudioContext.baseLatency + outputLatency using exponential moving
  * average to filter browser jitter (especially Chrome). Persists the smoothed
  * value to storage for cross-session consistency.
+ *
+ * outputLatency is device-derived, so it follows the actual output path
+ * (built-in speakers, USB DAC, Bluetooth) as it changes at runtime.
  */
 
 import type { SendspinStorage } from "../types";
+
+/**
+ * Stand-in for AudioContext.outputLatency on browsers that do not implement it
+ * (Safari and iOS Safari before 18.4), which report baseLatency only.
+ *
+ * Estimated from the 40-50ms gap observed between Safari and browsers that do
+ * report the property on comparable hardware; it is a stand-in, not a
+ * measurement of the current device. Used only when the property is absent, so a
+ * reported 0 is taken at face value. Exported for tests.
+ */
+export const UNREPORTED_OUTPUT_LATENCY_SEC = 0.04;
 
 const OUTPUT_LATENCY_ALPHA = 0.01;
 const OUTPUT_LATENCY_STORAGE_KEY = "sendspin-output-latency-us";
@@ -51,7 +65,12 @@ export class OutputLatencyTracker {
   getRawUs(audioContext: AudioContext | null): number {
     if (!audioContext) return 0;
     const baseLatency = audioContext.baseLatency ?? 0;
-    const outputLatency = audioContext.outputLatency ?? 0;
+    const reportedOutputLatency = audioContext.outputLatency;
+    const outputLatency =
+      typeof reportedOutputLatency === "number" &&
+      Number.isFinite(reportedOutputLatency)
+        ? reportedOutputLatency
+        : UNREPORTED_OUTPUT_LATENCY_SEC;
     return (baseLatency + outputLatency) * 1_000_000;
   }
 

--- a/src/audio/output-latency-tracker.ts
+++ b/src/audio/output-latency-tracker.ts
@@ -17,14 +17,32 @@ import type { SendspinStorage } from "../types";
  *
  * Estimated from the 40-50ms gap observed between Safari and browsers that do
  * report the property on comparable hardware; it is a stand-in, not a
- * measurement of the current device. Used only when the property is absent, so a
- * reported 0 is taken at face value. Exported for tests.
+ * measurement of the current device. Used only when the property is absent or
+ * unusable, so a reported 0 is taken at face value. Exported for tests.
  */
 export const UNREPORTED_OUTPUT_LATENCY_SEC = 0.04;
 
 const OUTPUT_LATENCY_ALPHA = 0.01;
 const OUTPUT_LATENCY_STORAGE_KEY = "sendspin-output-latency-us";
 const OUTPUT_LATENCY_PERSIST_INTERVAL_MS = 10_000;
+
+/**
+ * Resolve a latency the AudioContext reports, in seconds.
+ *
+ * Falls back when the property is missing or holds a value that cannot be a
+ * latency, so a single bad reading cannot reach the smoother, where it would
+ * stick for the lifetime of the stream.
+ */
+function resolveLatencySec(
+  reportedSec: number | undefined,
+  fallbackSec: number,
+): number {
+  const usable =
+    typeof reportedSec === "number" &&
+    Number.isFinite(reportedSec) &&
+    reportedSec >= 0;
+  return usable ? reportedSec : fallbackSec;
+}
 
 export class OutputLatencyTracker {
   private smoothedOutputLatencyUs: number | null = null;
@@ -64,13 +82,11 @@ export class OutputLatencyTracker {
   /** Get raw output latency in microseconds from AudioContext. */
   getRawUs(audioContext: AudioContext | null): number {
     if (!audioContext) return 0;
-    const baseLatency = audioContext.baseLatency ?? 0;
-    const reportedOutputLatency = audioContext.outputLatency;
-    const outputLatency =
-      typeof reportedOutputLatency === "number" &&
-      Number.isFinite(reportedOutputLatency)
-        ? reportedOutputLatency
-        : UNREPORTED_OUTPUT_LATENCY_SEC;
+    const baseLatency = resolveLatencySec(audioContext.baseLatency, 0);
+    const outputLatency = resolveLatencySec(
+      audioContext.outputLatency,
+      UNREPORTED_OUTPUT_LATENCY_SEC,
+    );
     return (baseLatency + outputLatency) * 1_000_000;
   }
 

--- a/src/audio/scheduler.ts
+++ b/src/audio/scheduler.ts
@@ -45,7 +45,6 @@ const RATE_CORRECTION_FIRM = 0.005;
 
 // EMA weight for the sync error. Lower smooths clock noise but slows drift response. Exported only for tests.
 export const SYNC_ERROR_ALPHA = 0.05;
-const SCHEDULE_HEADROOM_SEC = 0.2;
 const SCHEDULE_HORIZON_PRECISE_SEC = 20;
 const SCHEDULE_HORIZON_GOOD_SEC = 8;
 const SCHEDULE_HORIZON_POOR_SEC = 4;
@@ -237,6 +236,16 @@ export class AudioScheduler {
       .immediateDelayCutover;
   }
 
+  /**
+   * Smoothed baseLatency + outputLatency in seconds: how long audio handed to
+   * the renderer takes to reach the output port. Read on every scheduling pass
+   * (even with compensation disabled) because the clock source needs it to keep
+   * both of its clocks in the render-clock domain.
+   */
+  private measurePlayoutLatencySec(): number {
+    return this.latencyTracker.getSmoothedUs(this.audioContext) / 1_000_000;
+  }
+
   private getTargetScheduledHorizonSec(): number {
     if (this.isCastRuntime) {
       return CAST_SCHEDULE_HORIZON_SEC;
@@ -333,8 +342,9 @@ export class AudioScheduler {
       return;
     }
 
+    const playoutLatencySec = this.measurePlayoutLatencySec();
     const { audioContextTimeSec, audioContextRawTimeSec, nowMs, nowUs } =
-      this.clockSource.getTimingSnapshot(this.audioContext);
+      this.clockSource.getTimingSnapshot(this.audioContext, playoutLatencySec);
     this.pruneExpiredScheduledSources(audioContextRawTimeSec);
     if (this.getScheduledAheadSec(audioContextRawTimeSec) <= 0) {
       this.recorrectionMonitor.resetCheckState();
@@ -343,7 +353,7 @@ export class AudioScheduler {
     }
 
     const outputLatencySec = this.useOutputLatencyCompensation
-      ? this.latencyTracker.getSmoothedUs(this.audioContext) / 1_000_000
+      ? playoutLatencySec
       : 0;
     const targetPlaybackTime = this.computeTargetPlaybackTime(
       this.lastScheduledServerTime,
@@ -796,16 +806,20 @@ export class AudioScheduler {
     this.audioBufferQueue.sort((a, b) => a.serverTime - b.serverTime);
     if (!this.timeFilter.is_synchronized) return;
 
+    const playoutLatencySec = this.measurePlayoutLatencySec();
     const {
       audioContextTimeSec: audioContextTime,
       audioContextRawTimeSec,
       nowMs,
       nowUs,
-    } = this.clockSource.getTimingSnapshot(this.audioContext);
+    } = this.clockSource.getTimingSnapshot(
+      this.audioContext,
+      playoutLatencySec,
+    );
     this.pruneExpiredScheduledSources(audioContextRawTimeSec);
 
     const outputLatencySec = this.useOutputLatencyCompensation
-      ? this.latencyTracker.getSmoothedUs(this.audioContext) / 1_000_000
+      ? playoutLatencySec
       : 0;
     const syncDelaySec = this.syncDelayMs / 1000;
     const targetScheduledHorizonSec = this.getTargetScheduledHorizonSec();
@@ -1015,6 +1029,16 @@ export class AudioScheduler {
     this.emitStatusLog(nowMs);
   }
 
+  /**
+   * AudioContext time at which a chunk must be started so its first sample
+   * leaves the audio output port at the instant the server stamped it for.
+   *
+   * `audioContextTime` is the render clock, the same domain `source.start()`
+   * takes; audio handed to the renderer becomes audible one output latency
+   * later, so that latency is subtracted. Chunks whose target has already passed
+   * are dropped by the caller rather than shifted forward, which would render
+   * them late.
+   */
   private computeTargetPlaybackTime(
     serverTimeUs: number,
     audioContextTime: number,
@@ -1023,9 +1047,7 @@ export class AudioScheduler {
   ): number {
     const chunkClientTimeUs = this.timeFilter.computeClientTime(serverTimeUs);
     const deltaSec = (chunkClientTimeUs - nowUs) / 1_000_000;
-    return (
-      audioContextTime + deltaSec + SCHEDULE_HEADROOM_SEC - outputLatencySec
-    );
+    return audioContextTime + deltaSec - outputLatencySec;
   }
 
   startAudioElement(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,35 +35,6 @@ function detectIsCastRuntime(): boolean {
   return /CrKey/i.test(navigator.userAgent);
 }
 
-function detectIsSafari(): boolean {
-  if (typeof navigator === "undefined") return false;
-  const ua = navigator.userAgent;
-  return /Safari/i.test(ua) && !/Chrome/i.test(ua);
-}
-
-function detectIsMac(): boolean {
-  if (typeof navigator === "undefined") return false;
-  return /Macintosh/i.test(navigator.userAgent);
-}
-
-function detectIsWindows(): boolean {
-  if (typeof navigator === "undefined") return false;
-  return /Windows/i.test(navigator.userAgent);
-}
-
-/**
- * Get platform-specific default static delay in milliseconds.
- * Based on testing across various platforms and browsers.
- */
-function getDefaultSyncDelay(): number {
-  if (detectIsIOS()) return 250;
-  if (detectIsAndroid()) return 200;
-  if (detectIsMac()) return detectIsSafari() ? 190 : 150;
-  if (detectIsWindows()) return 250;
-  // Linux and others
-  return 200;
-}
-
 // Add a small cushion beyond the measured buffered runway so delayed timer
 // delivery does not cut playback off just before the last scheduled audio ends.
 const DISCONNECT_PLAYBACK_RESET_GRACE_MS = 250;
@@ -111,7 +82,7 @@ export class SendspinPlayer {
       codecs: config.codecs,
       bufferCapacity: config.bufferCapacity,
       syncDelay: config.syncDelay,
-      defaultSyncDelay: getDefaultSyncDelay(),
+      defaultSyncDelay: config.defaultSyncDelay,
       storage,
       requiredLeadTimeMs: config.requiredLeadTimeMs,
       minBufferMs: config.minBufferMs,
@@ -388,10 +359,4 @@ export { SendspinDecoder } from "./audio/decoder";
 export { AudioScheduler } from "./audio/scheduler";
 
 // Export platform detection utilities
-export {
-  detectIsAndroid,
-  detectIsIOS,
-  detectIsMobile,
-  detectIsCastRuntime,
-  getDefaultSyncDelay,
-};
+export { detectIsAndroid, detectIsIOS, detectIsMobile, detectIsCastRuntime };

--- a/src/types.ts
+++ b/src/types.ts
@@ -448,7 +448,12 @@ export interface SendspinCoreConfig {
    * Allowed range: 0-5000.
    * Runtime update behavior depends on the active correction mode settings.
    * Falls back to a persisted value, then `defaultSyncDelay`, then 0.
-   * SendspinPlayer supplies a browser/platform-specific heuristic as that default.
+   *
+   * The default of 0 means audio leaves the audio output port at the instant the
+   * server stamped it for, matching the protocol default. Only set this to
+   * compensate for latency the SDK cannot see (an amplifier, external speakers,
+   * a Bluetooth link), not for browser output latency, which is measured and
+   * compensated automatically via `useOutputLatencyCompensation`.
    *
    * Server-commanded delays (set_static_delay) are persisted via `storage` and
    * restored on the next connect. Passing `syncDelay` explicitly overrides any
@@ -458,7 +463,7 @@ export interface SendspinCoreConfig {
 
   /**
    * Fallback static delay used when neither `syncDelay` nor a persisted value
-   * is available. SendspinPlayer sets this to a platform-specific heuristic.
+   * is available. Defaults to 0.
    * @internal
    */
   defaultSyncDelay?: number;

--- a/tests/unit/clock-source.test.ts
+++ b/tests/unit/clock-source.test.ts
@@ -169,6 +169,92 @@ describe("ClockSource", () => {
     });
   });
 
+  describe("playout-latency normalization", () => {
+    // Real browsers put getOutputTimestamp().contextTime one output latency
+    // behind currentTime (measured in Chromium/macOS: 20.9ms lag vs a reported
+    // baseLatency + outputLatency of 21.3ms). Both clock sources must report the
+    // render clock, so the caller-supplied latency is added back.
+    function laggingCtx(base: { currentTime: number }, latencySec: number) {
+      return makeCtx({
+        currentTime: () => base.currentTime,
+        getOutputTimestamp: () => ({
+          contextTime: base.currentTime - latencySec,
+          performanceTime: nowMs,
+        }),
+      });
+    }
+
+    function promote(
+      cs: ClockSource,
+      ctx: AudioContext,
+      base: { currentTime: number },
+      latencySec: number,
+    ): number {
+      let snapshot = cs.getTimingSnapshot(ctx, latencySec);
+      for (let i = 0; i < 8; i++) {
+        nowMs += 150;
+        base.currentTime += 0.15;
+        snapshot = cs.getTimingSnapshot(ctx, latencySec);
+      }
+      return snapshot.audioContextTimeSec;
+    }
+
+    it("reports the render clock, not the playout clock, once promoted", () => {
+      const latencySec = 0.021333333333333333;
+      const base = { currentTime: 10.0 };
+      const cs = new ClockSource();
+      const derived = promote(
+        cs,
+        laggingCtx(base, latencySec),
+        base,
+        latencySec,
+      );
+
+      expect(cs.active).toBe("timestamp");
+      expect(derived).toBeCloseTo(base.currentTime, 6);
+    });
+
+    it("trails the render clock by the latency when none is supplied", () => {
+      const latencySec = 0.021333333333333333;
+      const base = { currentTime: 10.0 };
+      const cs = new ClockSource();
+      // Passing 0 leaves contextTime in the playout domain: the promoted clock
+      // then reads one latency early, which would schedule audio that much late.
+      const derived = promote(cs, laggingCtx(base, latencySec), base, 0);
+
+      expect(cs.active).toBe("timestamp");
+      expect(base.currentTime - derived).toBeCloseTo(latencySec, 6);
+    });
+
+    it("still promotes on devices whose output latency exceeds the divergence tolerance", () => {
+      // 300ms of latency (e.g. a Bluetooth sink) exceeds the 250ms timestamp/raw
+      // divergence tolerance, so without normalization every sample is rejected.
+      const latencySec = 0.3;
+
+      const normalizedBase = { currentTime: 10.0 };
+      const normalized = new ClockSource();
+      promote(
+        normalized,
+        laggingCtx(normalizedBase, latencySec),
+        normalizedBase,
+        latencySec,
+      );
+      expect(normalized.active).toBe("timestamp");
+
+      nowMs = 1000;
+      const unnormalizedBase = { currentTime: 10.0 };
+      const unnormalized = new ClockSource();
+      promote(
+        unnormalized,
+        laggingCtx(unnormalizedBase, latencySec),
+        unnormalizedBase,
+        0,
+      );
+      expect(unnormalized.active).toBe("estimated");
+      expect(unnormalized.lastRejectReason).toMatch(/divergence/);
+    });
+  });
+
   describe("timestamp rejection / demotion", () => {
     it("rejects and never promotes when contextTime diverges from raw beyond tolerance", () => {
       const base = { contextTime: 10.0 };

--- a/tests/unit/output-latency-tracker.test.ts
+++ b/tests/unit/output-latency-tracker.test.ts
@@ -10,7 +10,10 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { OutputLatencyTracker } from "../../src/audio/output-latency-tracker";
+import {
+  OutputLatencyTracker,
+  UNREPORTED_OUTPUT_LATENCY_SEC,
+} from "../../src/audio/output-latency-tracker";
 import type { SendspinStorage } from "../../src/types";
 
 const ALPHA = 0.01;
@@ -43,10 +46,28 @@ describe("OutputLatencyTracker", () => {
       expect(t.getRawUs(fakeCtx(0.005, 0.02))).toBeCloseTo(25000, 6);
     });
 
-    it("treats missing latency fields as 0", () => {
+    it("substitutes the fallback when outputLatency is unreported (Safari < 18.4)", () => {
+      const t = new OutputLatencyTracker(null);
+      // baseLatency shipped in Safari 14.1, outputLatency only in 18.4.
+      const ctx = { baseLatency: 0.005 } as unknown as AudioContext;
+      expect(t.getRawUs(ctx)).toBeCloseTo(
+        (0.005 + UNREPORTED_OUTPUT_LATENCY_SEC) * 1_000_000,
+        6,
+      );
+    });
+
+    it("takes a reported outputLatency of 0 at face value", () => {
+      const t = new OutputLatencyTracker(null);
+      expect(t.getRawUs(fakeCtx(0.005, 0))).toBeCloseTo(5000, 6);
+    });
+
+    it("falls back for both fields when the context reports no latency at all", () => {
       const t = new OutputLatencyTracker(null);
       const ctx = {} as unknown as AudioContext;
-      expect(t.getRawUs(ctx)).toBe(0);
+      expect(t.getRawUs(ctx)).toBeCloseTo(
+        UNREPORTED_OUTPUT_LATENCY_SEC * 1_000_000,
+        6,
+      );
     });
   });
 

--- a/tests/unit/output-latency-tracker.test.ts
+++ b/tests/unit/output-latency-tracker.test.ts
@@ -69,6 +69,23 @@ describe("OutputLatencyTracker", () => {
         6,
       );
     });
+
+    it("substitutes the fallback for an unusable outputLatency reading", () => {
+      const t = new OutputLatencyTracker(null);
+      for (const unusable of [NaN, Infinity, -0.01]) {
+        expect(t.getRawUs(fakeCtx(0.005, unusable))).toBeCloseTo(
+          (0.005 + UNREPORTED_OUTPUT_LATENCY_SEC) * 1_000_000,
+          6,
+        );
+      }
+    });
+
+    it("ignores an unusable baseLatency reading", () => {
+      const t = new OutputLatencyTracker(null);
+      for (const unusable of [NaN, Infinity, -0.01]) {
+        expect(t.getRawUs(fakeCtx(unusable, 0.02))).toBeCloseTo(20000, 6);
+      }
+    });
   });
 
   describe("EMA smoothing", () => {

--- a/tests/unit/render-offset.test.ts
+++ b/tests/unit/render-offset.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Rendering-offset tests for AudioScheduler.
+ *
+ * The Sendspin spec defines an audio chunk timestamp as "server clock time in
+ * microseconds when the first sample should be output", i.e. when it leaves the
+ * device's audio port. These tests assert that end of the contract: a chunk
+ * stamped for server instant T must be *audible* at the client instant T maps
+ * to, with no constant offset.
+ *
+ * Unlike scheduler.test.ts (which asserts scheduled `source.start()` values),
+ * the fake AudioContext here models the real Chrome clock relationship so the
+ * audible instant can be derived from the scheduled one. Measured in Chromium
+ * on macOS at 48kHz with an active source (see PLAYOUT_LATENCY_SEC below):
+ *
+ *   currentTime - (getOutputTimestamp().contextTime + freshness) = 20.9ms
+ *   baseLatency + outputLatency                                  = 21.3ms
+ *
+ * So `currentTime` is the render clock (leading edge, where source.start()
+ * places audio) and `contextTime` is the playout clock (trailing edge, what is
+ * leaving the port now), the two separated by baseLatency + outputLatency.
+ * Audio started at render-clock time S is therefore audible one latency later:
+ *
+ *   audible_wall(S) = wall(S) + baseLatency + outputLatency
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { AudioScheduler } from "../../src/audio/scheduler";
+import { StateManager } from "../../src/core/state-manager";
+import { SendspinTimeFilter } from "../../src/core/time-filter";
+import type { DecodedAudioChunk, StreamFormat } from "../../src/types";
+
+const SAMPLE_RATE = 48000;
+
+// Chrome/macOS measured values (see file header).
+const BASE_LATENCY_SEC = 0.005333333333333333;
+const OUTPUT_LATENCY_SEC = 0.016;
+const PLAYOUT_LATENCY_SEC = BASE_LATENCY_SEC + OUTPUT_LATENCY_SEC;
+
+// Virtual wall clock (performance.now() domain) and the AudioContext time that
+// corresponds to it. Both advance 1:1.
+const WALL_EPOCH_MS = 5_000_000;
+const CTX_EPOCH_SEC = 1000;
+
+// Server clock runs ahead of the client clock by this much.
+const SERVER_OFFSET_US = 12_345_678;
+
+// Chunks are stamped this far in the future, as a real server does (the client
+// asks for lead time via required_lead_time_ms).
+const CHUNK_LEAD_SEC = 0.5;
+
+let nowMs = WALL_EPOCH_MS;
+
+function rawCurrentTime(): number {
+  return CTX_EPOCH_SEC + (nowMs - WALL_EPOCH_MS) / 1000;
+}
+
+/** Wall-clock instant (ms) at which audio started at render time `startSec` is audible. */
+function audibleWallMs(startSec: number): number {
+  return (
+    WALL_EPOCH_MS +
+    (startSec - CTX_EPOCH_SEC) * 1000 +
+    PLAYOUT_LATENCY_SEC * 1000
+  );
+}
+
+class FakeAudioBuffer {
+  duration: number;
+  private channels: Float32Array[];
+  constructor(
+    public numberOfChannels: number,
+    public length: number,
+    public sampleRate: number,
+  ) {
+    this.duration = length / sampleRate;
+    this.channels = Array.from(
+      { length: numberOfChannels },
+      () => new Float32Array(length),
+    );
+  }
+  getChannelData(ch: number): Float32Array {
+    return this.channels[ch];
+  }
+}
+
+class FakeBufferSource {
+  buffer: FakeAudioBuffer | null = null;
+  playbackRate = { value: 1.0 };
+  onended: (() => void) | null = null;
+  started: number | null = null;
+  constructor(private ctx: ChromeLikeAudioContext) {}
+  connect() {}
+  start(when: number) {
+    this.started = when;
+    this.ctx.startedSources.push(this);
+  }
+  stop() {}
+}
+
+class FakeGainNode {
+  gain = {
+    value: 1.0,
+    setTargetAtTime(target: number) {
+      this.value = target;
+    },
+  };
+  connect() {}
+}
+
+class ChromeLikeAudioContext {
+  state: "running" | "suspended" | "closed" = "running";
+  sampleRate: number;
+  baseLatency = BASE_LATENCY_SEC;
+  outputLatency = OUTPUT_LATENCY_SEC;
+  destination = {};
+  startedSources: FakeBufferSource[] = [];
+  /** getOutputTimestamp() is only exposed once enabled, mirroring browser support. */
+  outputTimestampEnabled = false;
+
+  constructor(opts?: { sampleRate?: number }) {
+    this.sampleRate = opts?.sampleRate ?? SAMPLE_RATE;
+  }
+  get currentTime(): number {
+    return rawCurrentTime();
+  }
+  getOutputTimestamp():
+    | { contextTime: number; performanceTime: number }
+    | undefined {
+    if (!this.outputTimestampEnabled) return undefined;
+    // Playout clock: what is leaving the port right now.
+    return {
+      contextTime: rawCurrentTime() - PLAYOUT_LATENCY_SEC,
+      performanceTime: nowMs,
+    };
+  }
+  createBuffer(channels: number, length: number, sampleRate: number) {
+    return new FakeAudioBuffer(channels, length, sampleRate);
+  }
+  createGain() {
+    return new FakeGainNode();
+  }
+  createBufferSource() {
+    return new FakeBufferSource(this);
+  }
+  createMediaStreamDestination() {
+    return { stream: {} };
+  }
+  resume() {
+    this.state = "running";
+    return Promise.resolve();
+  }
+  close() {
+    this.state = "closed";
+    return Promise.resolve();
+  }
+}
+
+const PCM_FORMAT: StreamFormat = {
+  codec: "pcm",
+  sample_rate: SAMPLE_RATE,
+  channels: 2,
+  bit_depth: 16,
+};
+
+let lastCtx: ChromeLikeAudioContext | null = null;
+
+interface Harness {
+  scheduler: AudioScheduler;
+  ctx: ChromeLikeAudioContext;
+  timeFilter: SendspinTimeFilter;
+}
+
+function setup(
+  opts: {
+    syncDelayMs?: number;
+    useOutputLatencyCompensation?: boolean;
+    outputTimestamp?: boolean;
+  } = {},
+): Harness {
+  const stateManager = new StateManager();
+  const timeFilter = new SendspinTimeFilter();
+  // A single measurement is enough to synchronize the filter; with one sample it
+  // reports zero drift, so clientTime(serverUs) === serverUs - SERVER_OFFSET_US.
+  timeFilter.update(SERVER_OFFSET_US, 1000, nowMs * 1000);
+  expect(timeFilter.is_synchronized).toBe(true);
+
+  const scheduler = new AudioScheduler({
+    stateManager,
+    timeFilter,
+    syncDelayMs: opts.syncDelayMs ?? 0,
+    useOutputLatencyCompensation: opts.useOutputLatencyCompensation ?? true,
+    correctionMode: "sync",
+  });
+  stateManager.currentStreamFormat = PCM_FORMAT;
+  scheduler.initAudioContext();
+  const ctx = lastCtx!;
+  ctx.outputTimestampEnabled = opts.outputTimestamp ?? false;
+  stateManager.isPlaying = true;
+  return { scheduler, ctx, timeFilter };
+}
+
+function makeChunk(serverTimeUs: number, frames = SAMPLE_RATE / 10) {
+  return {
+    samples: [new Float32Array(frames), new Float32Array(frames)],
+    sampleRate: SAMPLE_RATE,
+    serverTimeUs,
+    generation: 0,
+  } satisfies DecodedAudioChunk;
+}
+
+/**
+ * Drive enough timing snapshots for ClockSource to promote to the
+ * getOutputTimestamp-derived clock (6 good samples spanning >=750ms).
+ */
+function promoteToTimestampClock(scheduler: AudioScheduler): void {
+  for (let i = 0; i < 7; i++) {
+    nowMs += 150;
+    scheduler.processAudioQueue();
+  }
+}
+
+/**
+ * Schedule one chunk stamped `CHUNK_LEAD_SEC` in the future and return how far
+ * its audible instant lands from the instant the server asked for, in ms.
+ * Positive means the client renders late.
+ */
+function measureRenderOffsetMs(h: Harness): number {
+  const serverTimeUs = Math.round(
+    (nowMs + CHUNK_LEAD_SEC * 1000) * 1000 + SERVER_OFFSET_US,
+  );
+  h.scheduler.handleDecodedChunk(makeChunk(serverTimeUs));
+  h.scheduler.processAudioQueue();
+
+  expect(h.ctx.startedSources.length).toBe(1);
+  const startedAt = h.ctx.startedSources[0].started!;
+  const intendedWallMs = h.timeFilter.computeClientTime(serverTimeUs) / 1000;
+  return audibleWallMs(startedAt) - intendedWallMs;
+}
+
+beforeEach(() => {
+  nowMs = WALL_EPOCH_MS;
+  lastCtx = null;
+  vi.stubGlobal("AudioContext", function (opts?: { sampleRate?: number }) {
+    lastCtx = new ChromeLikeAudioContext(opts);
+    return lastCtx;
+  });
+  vi.stubGlobal("navigator", {});
+  vi.stubGlobal("document", {
+    createElement: () => ({ style: {}, play: () => Promise.resolve() }),
+    body: { appendChild: () => {} },
+  });
+  if (typeof globalThis.performance === "undefined") {
+    vi.stubGlobal("performance", { now: () => nowMs });
+  } else {
+    vi.spyOn(performance, "now").mockImplementation(() => nowMs);
+  }
+  vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("AudioScheduler rendering offset", () => {
+  it("renders a chunk audible at its server timestamp (estimated clock)", () => {
+    const h = setup();
+    const offsetMs = measureRenderOffsetMs(h);
+    console.info(`estimated clock: render offset ${offsetMs.toFixed(1)}ms`);
+    expect(offsetMs).toBeCloseTo(0, 3);
+  });
+
+  it("renders a chunk audible at its server timestamp (output-timestamp clock)", () => {
+    const h = setup({ outputTimestamp: true });
+    promoteToTimestampClock(h.scheduler);
+    const offsetMs = measureRenderOffsetMs(h);
+    console.info(`timestamp clock: render offset ${offsetMs.toFixed(1)}ms`);
+    expect(offsetMs).toBeCloseTo(0, 3);
+  });
+
+  it("keeps the render offset identical across a clock-source promotion", () => {
+    const estimated = setup();
+    const estimatedOffsetMs = measureRenderOffsetMs(estimated);
+
+    const promoted = setup({ outputTimestamp: true });
+    promoteToTimestampClock(promoted.scheduler);
+    const promotedOffsetMs = measureRenderOffsetMs(promoted);
+
+    // A step here would be audible as a jump when the clock source promotes
+    // mid-playback.
+    expect(promotedOffsetMs - estimatedOffsetMs).toBeCloseTo(0, 3);
+  });
+
+  it("renders exactly staticDelay earlier when a static delay is set", () => {
+    const syncDelayMs = 120;
+    const h = setup({ syncDelayMs });
+    // Positive static delay means "play earlier to compensate for downstream
+    // latency", so the port instant moves ahead of the server timestamp.
+    expect(measureRenderOffsetMs(h)).toBeCloseTo(-syncDelayMs, 3);
+  });
+
+  it("renders one output latency late when latency compensation is disabled", () => {
+    const expectedMs = PLAYOUT_LATENCY_SEC * 1000;
+
+    const estimated = setup({ useOutputLatencyCompensation: false });
+    expect(measureRenderOffsetMs(estimated)).toBeCloseTo(expectedMs, 3);
+
+    // Same result on both clock sources: disabling compensation must not mean
+    // "compensated on one clock, uncompensated on the other".
+    const promoted = setup({
+      useOutputLatencyCompensation: false,
+      outputTimestamp: true,
+    });
+    promoteToTimestampClock(promoted.scheduler);
+    expect(measureRenderOffsetMs(promoted)).toBeCloseTo(expectedMs, 3);
+  });
+});

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -10,8 +10,11 @@
  *
  * Scheduling math reference (scheduler.ts computeTargetPlaybackTime):
  *   targetPlaybackTime = ctxTime + (clientTime(serverUs) - nowUs)/1e6
- *                        + SCHEDULE_HEADROOM_SEC(0.2) - outputLatencySec
+ *                        - outputLatencySec
  * We disable output-latency compensation in most tests to keep math clean.
+ *
+ * These tests assert scheduled `source.start()` times; render-offset.test.ts
+ * covers the audible instant those add up to.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
@@ -20,7 +23,6 @@ import { StateManager } from "../../src/core/state-manager";
 import type { DecodedAudioChunk, StreamFormat } from "../../src/types";
 
 const SAMPLE_RATE = 48000;
-const HEADROOM_SEC = 0.2;
 
 // ---------------------------------------------------------------------------
 // Fake Web Audio
@@ -334,7 +336,7 @@ describe("AudioScheduler AudioContext lifecycle", () => {
 });
 
 describe("AudioScheduler scheduling math", () => {
-  it("first chunk schedules at ctxTime + headroom when chunk client time == now", () => {
+  it("first chunk schedules at ctxTime when chunk client time == now", () => {
     const { scheduler, ctx, tf } = setup();
     // serverTime maps to clientTime == nowUs -> delta 0
     const serverTime = nowUs();
@@ -344,21 +346,22 @@ describe("AudioScheduler scheduling math", () => {
 
     expect(ctx.startedSources.length).toBe(1);
     const src = ctx.startedSources[0];
-    // scheduleTime = playbackTime - syncDelay(0) = target = ctxTime + 0.2
-    expect(src.started!).toBeCloseTo(ctx.currentTime + HEADROOM_SEC, 6);
+    // The target is the mapped client instant itself.
+    expect(src.started!).toBeCloseTo(ctx.currentTime, 6);
     expect(src.playbackRate.value).toBe(1.0);
   });
 
   it("subtracts syncDelayMs from the schedule time of the first chunk", () => {
     const syncDelayMs = 50;
     const { scheduler, ctx } = setup({ syncDelayMs });
-    scheduler.handleDecodedChunk(makeChunk(nowUs(), 0));
+    // 1s of lead so the earlier start is not clamped up to "now"
+    scheduler.handleDecodedChunk(makeChunk(nowUs() + 1_000_000, 0));
     scheduler.processAudioQueue();
 
     const src = ctx.startedSources[0];
-    // playbackTime = ctxTime + 0.2 ; scheduleTime = playbackTime - 0.05
+    // playbackTime = ctxTime + 1 ; scheduleTime = playbackTime - 0.05
     expect(src.started!).toBeCloseTo(
-      ctx.currentTime + HEADROOM_SEC - syncDelayMs / 1000,
+      ctx.currentTime + 1 - syncDelayMs / 1000,
       6,
     );
   });
@@ -371,7 +374,7 @@ describe("AudioScheduler scheduling math", () => {
     scheduler.processAudioQueue();
 
     const src = ctx.startedSources[0];
-    expect(src.started!).toBeCloseTo(ctx.currentTime + 2 + HEADROOM_SEC, 6);
+    expect(src.started!).toBeCloseTo(ctx.currentTime + 2, 6);
   });
 });
 


### PR DESCRIPTION
The scheduler added a fixed 200ms of slack to every chunk before handing it to the audio output, so audio left the output port 200ms after the moment the server stamped it for. The platform-specific default delays (150-250ms) were mostly there to cancel that slack out again, which made the timing hard to reason about and left web players slightly behind native Sendspin speakers in the same group.

- Schedule audio to leave the output port at the moment the server stamped it for
- Removed the platform-specific default delays; the default static delay is now 0, like the protocol prescribes
- The two internal audio clocks now use the same timebase, so playback no longer shifts slightly when the SDK switches between them
- Browsers that do not report their output latency (Safari before 18.4) now assume 40ms instead of 0
- Ignore output latency readings that cannot be a latency, instead of letting them settle into the smoother
- Dropped the `getDefaultSyncDelay()` export, which only returned those platform defaults
- Added tests that measure when audio actually becomes audible, so a constant offset like this cannot creep back in

If you set a static delay by hand to compensate for the old timing, reset it to 0.
