### PR TITLE
Restore queued audio timestamp order

### DIFF
--- a/src/audio/scheduler.ts
+++ b/src/audio/scheduler.ts
@@ -641,6 +641,11 @@ export class AudioScheduler {
       cutCount++;
       return false;
     });
+    // Requeued sources predate the chunks still queued, and a cut from the drain
+    // loop lands after that loop's own sort.
+    if (requeued > 0) {
+      this.audioBufferQueue.sort((a, b) => a.serverTime - b.serverTime);
+    }
     return { requeuedCount: requeued, cutCount, keptTailEndTimeSec };
   }
 

--- a/src/audio/scheduler.ts
+++ b/src/audio/scheduler.ts
@@ -885,7 +885,6 @@ export class AudioScheduler {
         }
         this.recorrectionMonitor.clearMinScheduleTime();
         playbackRate = 1.0;
-        chunk.buffer = this.copyBuffer(chunk.buffer);
       } else {
         const serverGapUs = chunk.serverTime - this.lastScheduledServerTime;
         const serverGapSec = serverGapUs / 1_000_000;
@@ -914,7 +913,6 @@ export class AudioScheduler {
             playbackRate = 1.0;
             this.currentCorrectionMethod = "resync";
             this.lastSamplesAdjusted = 0;
-            chunk.buffer = this.copyBuffer(chunk.buffer);
           } else if (Math.abs(correctionErrorMs) > thresholds.resyncAboveMs) {
             playbackTime = this.nextPlaybackTime;
             scheduleTime = this.nextScheduleTime;
@@ -926,14 +924,12 @@ export class AudioScheduler {
             this.currentCorrectionMethod =
               playbackRate === 1.0 ? "none" : "rate";
             this.lastSamplesAdjusted = 0;
-            chunk.buffer = this.copyBuffer(chunk.buffer);
           } else if (Math.abs(correctionErrorMs) < thresholds.deadbandBelowMs) {
             playbackTime = this.nextPlaybackTime;
             scheduleTime = this.nextScheduleTime;
             playbackRate = 1.0;
             this.currentCorrectionMethod = "none";
             this.lastSamplesAdjusted = 0;
-            chunk.buffer = this.copyBuffer(chunk.buffer);
           } else if (Math.abs(correctionErrorMs) <= thresholds.samplesBelowMs) {
             playbackTime = this.nextPlaybackTime;
             scheduleTime = this.nextScheduleTime;
@@ -967,7 +963,6 @@ export class AudioScheduler {
             this.currentCorrectionMethod =
               playbackRate === 1.0 ? "none" : "rate";
             this.lastSamplesAdjusted = 0;
-            chunk.buffer = this.copyBuffer(chunk.buffer);
           }
         } else {
           // Gap detected in server timestamps - hard resync (gated on cooldown)
@@ -982,7 +977,6 @@ export class AudioScheduler {
           playbackRate = 1.0;
           this.currentCorrectionMethod = "resync";
           this.lastSamplesAdjusted = 0;
-          chunk.buffer = this.copyBuffer(chunk.buffer);
         }
       }
 

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -581,6 +581,32 @@ describe("AudioScheduler cutover backlog handling", () => {
   });
 });
 
+describe("AudioScheduler cut requeue ordering", () => {
+  it("restores serverTime order when a cut requeues behind a queued chunk", () => {
+    const h = setup();
+    const base = nowUs();
+    // Two chunks scheduled, then a later one left queued.
+    h.scheduler.handleDecodedChunk(makeChunk(base, 0));
+    h.scheduler.handleDecodedChunk(makeChunk(base + 100_000, 0));
+    h.scheduler.processAudioQueue();
+    expect(h.ctx.startedSources.length).toBe(2);
+    h.tf.synchronized = false;
+    h.scheduler.handleDecodedChunk(makeChunk(base + 200_000, 0));
+
+    // A cut mirrors the one processAudioQueue makes mid-drain, after its sort.
+    (h.scheduler as any).cutScheduledSources(h.ctx.currentTime);
+
+    const queued = (h.scheduler as any).audioBufferQueue as Array<{
+      serverTime: number;
+    }>;
+    expect(queued.map((c) => c.serverTime)).toEqual([
+      base,
+      base + 100_000,
+      base + 200_000,
+    ]);
+  });
+});
+
 describe("AudioScheduler quality mode thresholds", () => {
   it("never uses playback-rate changes in quality mode", () => {
     const h = setup({ correctionMode: "quality" });


### PR DESCRIPTION
Cutting future scheduled sources requeued them after newer buffered chunks, violating server timestamp order on the next scheduling pass. Requeued audio is sorted before processing, and redundant `AudioBuffer` copies are removed from paths that do not mutate samples.