### PR TITLE
Reset stale static delays

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -22,7 +22,7 @@ const STORAGE_KEYS = {
   VOLUME: "sendspin-volume",
   MUTED: "sendspin-muted",
   // Shared with the SDK, which persists the static delay under this key.
-  SYNC_DELAY: "sendspin-static-delay-ms",
+  SYNC_DELAY: "sendspin-static-delay-ms-v2",
   REQUIRED_LEAD_TIME: "sendspin-required-lead-time",
   MIN_BUFFER: "sendspin-min-buffer",
   CORRECTION_MODE: "sendspin-correction-mode",

--- a/src/core/static-delay-store.ts
+++ b/src/core/static-delay-store.ts
@@ -6,7 +6,8 @@
 import type { SendspinStorage } from "../types";
 import { clampSyncDelayMs } from "../sync-delay";
 
-const STATIC_DELAY_STORAGE_KEY = "sendspin-static-delay-ms";
+// Ignore delays saved before fixed scheduling headroom was removed (#159).
+const STATIC_DELAY_STORAGE_KEY = "sendspin-static-delay-ms-v2";
 
 export class StaticDelayStore {
   constructor(private storage: SendspinStorage | null) {}

--- a/tests/unit/core.test.ts
+++ b/tests/unit/core.test.ts
@@ -19,7 +19,7 @@ function makeStorage(): SendspinStorage & { data: Map<string, string> } {
   };
 }
 
-const STATIC_DELAY_KEY = "sendspin-static-delay-ms";
+const STATIC_DELAY_KEY = "sendspin-static-delay-ms-v2";
 
 const PCM_FORMAT: StreamFormat = {
   codec: "pcm",
@@ -424,6 +424,18 @@ describe("SendspinCore static delay persistence", () => {
     });
 
     expect(core.getSyncDelayMs()).toBe(321);
+  });
+
+  it("ignores a delay persisted under the pre-v2 key", () => {
+    const storage = makeStorage();
+    storage.data.set("sendspin-static-delay-ms", "321");
+
+    const core = new SendspinCore({
+      baseUrl: "http://h",
+      storage,
+    });
+
+    expect(core.getSyncDelayMs()).toBe(0);
   });
 
   it("lets an explicit config.syncDelay override the persisted value", () => {


### PR DESCRIPTION
Static delays saved before #159 were calibrated against scheduling headroom that no longer exists, so restoring them can shift playback. The storage key is versioned to ignore those stale values while preserving persistence for newly calibrated delays.