### PR TITLE
Report all time sync measurements

### DIFF
--- a/src/core/time-filter.ts
+++ b/src/core/time-filter.ts
@@ -26,7 +26,9 @@ export interface TimeElement {
 
 export class SendspinTimeFilter {
   private _last_update: number = 0;
+  // Maturity gate for the state machine and adaptive forgetting, caps at 100.
   private _count: number = 0;
+  private _measurements_processed: number = 0;
 
   private _offset: number = 0.0;
   private _drift: number = 0.0;
@@ -92,6 +94,7 @@ export class SendspinTimeFilter {
 
     const dt = time_added - this._last_update;
     this._last_update = time_added;
+    this._measurements_processed += 1;
 
     const update_std_dev = max_error;
     const measurement_variance = update_std_dev * update_std_dev;
@@ -268,6 +271,7 @@ export class SendspinTimeFilter {
    */
   reset(): void {
     this._count = 0;
+    this._measurements_processed = 0;
     this._last_update = 0;
     this._offset = 0.0;
     this._drift = 0.0;
@@ -283,7 +287,7 @@ export class SendspinTimeFilter {
    * Get the number of time sync measurements processed.
    */
   get count(): number {
-    return this._count;
+    return this._measurements_processed;
   }
 
   /**

--- a/tests/unit/time-filter.test.ts
+++ b/tests/unit/time-filter.test.ts
@@ -29,6 +29,14 @@ describe("SendspinTimeFilter", () => {
   });
 
   describe("multiple measurements", () => {
+    it("reports measurements processed after the maturity gate caps", () => {
+      for (let i = 1; i <= 105; i++) {
+        filter.update(10000, 1000, i * 100000);
+      }
+
+      expect(filter.count).toBe(105);
+    });
+
     it("refines offset with consistent measurements", () => {
       // Simulate a constant 10ms offset
       const trueOffset = 10000; // 10ms in µs


### PR DESCRIPTION
The public time sync measurement count stopped at 100 because it shared the filter’s capped maturity counter. A separate uncapped counter now reports every accepted measurement while preserving the internal maturity gate.