### PR TITLE
Ignore closes before WebSocket opens

### DIFF
--- a/src/core/websocket-manager.ts
+++ b/src/core/websocket-manager.ts
@@ -168,9 +168,12 @@ export class WebSocketManager {
         this.ws = new WebSocket(url);
         this.ws.binaryType = "arraybuffer";
         this.shouldReconnect = true;
+        // Browsers fire close even for attempts that never opened.
+        let opened = false;
 
         this.ws.onopen = () => {
           console.log("Sendspin: WebSocket connected");
+          opened = true;
           const wasReconnecting = this.isReconnecting;
           this.isReconnecting = false;
           this.reconnectAttempt = 0;
@@ -199,7 +202,7 @@ export class WebSocketManager {
 
         this.ws.onclose = () => {
           console.log("Sendspin: WebSocket disconnected");
-          if (this.onCloseHandler) {
+          if (opened && this.onCloseHandler) {
             this.onCloseHandler();
           }
 

--- a/tests/unit/websocket-manager.test.ts
+++ b/tests/unit/websocket-manager.test.ts
@@ -208,6 +208,21 @@ describe("WebSocketManager extra", () => {
       ws.fireError(new Error("boom"));
       expect(onError).toHaveBeenCalled();
     });
+
+    it("does not report a close for a socket that never opened", () => {
+      const onClose = vi.fn();
+      void mgr.connect(
+        "ws://host/sendspin",
+        undefined,
+        undefined,
+        undefined,
+        onClose,
+      );
+
+      RichFakeWebSocket.instances[0].fireClose();
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
   });
 
   describe("disconnect", () => {


### PR DESCRIPTION
Browsers can emit a WebSocket close event for an attempt that never opened. The manager now reports connection closure only after open, avoiding teardown callbacks for sessions that never connected while leaving reconnect behavior unchanged.