### PR TITLE
Fix PCM bit depth handling

### DIFF
--- a/src/audio/decoder.ts
+++ b/src/audio/decoder.ts
@@ -114,7 +114,12 @@ export class SendspinDecoder {
     audioData: ArrayBuffer,
     format: StreamFormat,
   ): { samples: Float32Array[]; sampleRate: number } | null {
-    const bytesPerSample = (format.bit_depth || 16) / 8;
+    const bitDepth = format.bit_depth ?? 16;
+    if (bitDepth !== 16 && bitDepth !== 24 && bitDepth !== 32) {
+      console.warn(`Sendspin: unsupported PCM bit_depth ${bitDepth}`);
+      return null;
+    }
+    const bytesPerSample = bitDepth / 8;
     const dataView = new DataView(audioData);
     const numSamples =
       audioData.byteLength / (bytesPerSample * format.channels);
@@ -131,9 +136,9 @@ export class SendspinDecoder {
         const offset = (i * format.channels + channel) * bytesPerSample;
         let sample = 0;
 
-        if (format.bit_depth === 16) {
+        if (bitDepth === 16) {
           sample = dataView.getInt16(offset, true) / 32768.0;
-        } else if (format.bit_depth === 24) {
+        } else if (bitDepth === 24) {
           const byte1 = dataView.getUint8(offset);
           const byte2 = dataView.getUint8(offset + 1);
           const byte3 = dataView.getUint8(offset + 2);
@@ -142,7 +147,7 @@ export class SendspinDecoder {
             int24 |= 0xff000000;
           }
           sample = int24 / 8388608.0;
-        } else if (format.bit_depth === 32) {
+        } else if (bitDepth === 32) {
           sample = dataView.getInt32(offset, true) / 2147483648.0;
         }
 

--- a/tests/unit/decoder.test.ts
+++ b/tests/unit/decoder.test.ts
@@ -274,6 +274,47 @@ describe("SendspinDecoder", () => {
     });
   });
 
+  describe("PCM bit depth handling", () => {
+    it("decodes an omitted bit_depth as 16-bit", async () => {
+      const format: StreamFormat = {
+        codec: "pcm",
+        sample_rate: 48000,
+        channels: 2,
+      };
+
+      const pcmData = createPcm16Sine(960, 2);
+      await decoder.handleBinaryMessage(
+        buildBinaryMessage(1000000, pcmData.buffer),
+        format,
+        0,
+      );
+
+      expect(chunks.length).toBe(1);
+      expect(chunks[0].samples[0].length).toBe(960);
+      let peak = 0;
+      for (const s of chunks[0].samples[0]) peak = Math.max(peak, Math.abs(s));
+      expect(peak).toBeGreaterThan(0.4);
+    });
+
+    it("emits no chunk for an unsupported bit_depth", async () => {
+      const format: StreamFormat = {
+        codec: "pcm",
+        sample_rate: 48000,
+        channels: 2,
+        bit_depth: 8,
+      };
+
+      const pcmData = createPcm16Sine(960, 2);
+      await decoder.handleBinaryMessage(
+        buildBinaryMessage(1000000, pcmData.buffer),
+        format,
+        0,
+      );
+
+      expect(chunks.length).toBe(0);
+    });
+  });
+
   describe("generation filtering", () => {
     it("drops frames for old generations", async () => {
       const format: StreamFormat = {


### PR DESCRIPTION
PCM streams without `bit_depth` calculated 16-bit sample boundaries but skipped every decoding branch, producing silence. Missing depth now defaults to 16 bits, while unsupported depths are rejected instead of emitting silent samples.