### PR TITLE
Deploy GitHub Pages only on releases

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,10 +1,8 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
Pages currently redeploys on every merge to main even though the sample loads the latest published package from unpkg. Deploying only when a release is published keeps site updates aligned with package availability.