### PR TITLE
Fix npm releases and Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,8 +1,9 @@
 name: Deploy to GitHub Pages
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Publish release to npm]
+    types: [completed]
 
 permissions:
   contents: read
@@ -15,6 +16,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: unused
       - name: Set package version from tag
         run: npm version ${{ steps.vars.outputs.tag }} --no-git-tag-version --allow-same-version
       - name: Build package
@@ -72,6 +74,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: unused
 
       - name: Update npm for OIDC support
         run: npm install -g npm@latest


### PR DESCRIPTION
Releases fail during dependency installation because setup-node no longer provides Yarn with a placeholder authentication token. Supply that token only during installation, then deploy Pages from the default branch after npm publishing succeeds.