### PR TITLE
Fix npm releases (again)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: unused
       - name: Set package version from tag
         run: npm version ${{ steps.vars.outputs.tag }} --no-git-tag-version --allow-same-version
       - name: Build package


### PR DESCRIPTION
Release builds still fail because every Yarn command parses the npm authentication config created by setup-node. Keep registry authentication out of the build job and reserve it for the npm publishing job.