### PR TITLE
Fix Safari and iOS playback sync

### DIFF
--- a/src/audio/platform-output-latency.ts
+++ b/src/audio/platform-output-latency.ts
@@ -1,0 +1,28 @@
+type NavigatorInfo = Pick<Navigator, "userAgent"> &
+  Partial<Pick<Navigator, "platform" | "maxTouchPoints">>;
+
+const APPLE_WEBKIT_UNREPORTED_OUTPUT_LATENCY_MS = 100;
+
+// All iOS browsers use WebKit, while this output path is Safari-only on macOS.
+export function getUnreportedOutputLatencyMs(
+  navigatorInfo: NavigatorInfo | undefined = typeof navigator === "undefined"
+    ? undefined
+    : navigator,
+): number {
+  if (!navigatorInfo) return 0;
+
+  const { userAgent } = navigatorInfo;
+  // Keep detection local because importing helpers from index.ts would create a cycle.
+  const isIOS =
+    /iPad|iPhone|iPod/i.test(userAgent) ||
+    (navigatorInfo.platform === "MacIntel" &&
+      (navigatorInfo.maxTouchPoints ?? 0) > 1);
+  if (isIOS) return APPLE_WEBKIT_UNREPORTED_OUTPUT_LATENCY_MS;
+
+  const isMacSafari =
+    /Macintosh/i.test(userAgent) &&
+    /AppleWebKit/i.test(userAgent) &&
+    /Safari/i.test(userAgent) &&
+    !/Chrome|Chromium|Edg|OPR|Firefox/i.test(userAgent);
+  return isMacSafari ? APPLE_WEBKIT_UNREPORTED_OUTPUT_LATENCY_MS : 0;
+}

--- a/src/audio/scheduler.ts
+++ b/src/audio/scheduler.ts
@@ -22,6 +22,7 @@ import {
   RECORRECTION_CUTOVER_GUARD_SEC,
 } from "./recorrection-monitor";
 import { OutputLatencyTracker } from "./output-latency-tracker";
+import { getUnreportedOutputLatencyMs } from "./platform-output-latency";
 import { clampSyncDelayMs } from "../sync-delay";
 
 // Sync correction constants
@@ -145,7 +146,10 @@ export class AudioScheduler {
   private _lastStatusLogMs: number = 0;
   private _intervalResyncCount: number = 0;
 
+  // Controls reported and platform fallback output latency compensation.
   private useOutputLatencyCompensation: boolean;
+  // Accounts for output delay omitted by Safari and iOS WebKit latency APIs.
+  private unreportedOutputLatencySec: number;
   private scheduleTimeout: ReturnType<typeof setTimeout> | null = null;
   private refillTimeout: ReturnType<typeof setTimeout> | null = null;
   private queueProcessScheduled = false;
@@ -180,6 +184,9 @@ export class AudioScheduler {
     this._correctionMode = options.correctionMode ?? "sync";
     this.useOutputLatencyCompensation =
       options.useOutputLatencyCompensation ?? true;
+    this.unreportedOutputLatencySec = this.useOutputLatencyCompensation
+      ? getUnreportedOutputLatencyMs() / 1000
+      : 0;
 
     // Merge user-provided threshold overrides with defaults
     this.correctionThresholds = { ...DEFAULT_CORRECTION_THRESHOLDS };
@@ -415,7 +422,9 @@ export class AudioScheduler {
       clockDriftPercent: this.timeFilter.drift * 100,
       syncErrorMs: this.currentSyncErrorMs,
       resyncCount: this.resyncCount,
-      outputLatencyMs: this.latencyTracker.getRawUs(this.audioContext) / 1000,
+      outputLatencyMs:
+        this.latencyTracker.getRawUs(this.audioContext) / 1000 +
+        this.unreportedOutputLatencySec * 1000,
       playbackRate: this.currentPlaybackRate,
       correctionMethod: this.currentCorrectionMethod,
       samplesAdjusted: this.lastSamplesAdjusted,
@@ -462,7 +471,9 @@ export class AudioScheduler {
       : `pending(n=${this.timeFilter.count})`;
 
     const smoothedLatUs = this.latencyTracker.getSmoothedUs(this.audioContext);
-    const latMs = Math.round(smoothedLatUs / 1000);
+    const latMs = Math.round(
+      smoothedLatUs / 1000 + this.unreportedOutputLatencySec * 1000,
+    );
 
     console.log(
       `Sendspin: sync=${this.smoothedSyncErrorMs >= 0 ? "+" : ""}${this.smoothedSyncErrorMs.toFixed(1)}ms` +
@@ -826,7 +837,8 @@ export class AudioScheduler {
     const outputLatencySec = this.useOutputLatencyCompensation
       ? playoutLatencySec
       : 0;
-    const syncDelaySec = this.syncDelayMs / 1000;
+    const scheduleAdvanceSec =
+      this.syncDelayMs / 1000 + this.unreportedOutputLatencySec;
     const targetScheduledHorizonSec = this.getTargetScheduledHorizonSec();
 
     if (this.usesRecorrectionMonitor) this.recorrectionMonitor.start();
@@ -872,7 +884,7 @@ export class AudioScheduler {
       if (this.nextPlaybackTime === 0 || this.lastScheduledServerTime === 0) {
         this.recorrectionMonitor.armStartupGrace(nowMs, isTimestamp);
         playbackTime = targetPlaybackTime;
-        scheduleTime = playbackTime - syncDelaySec;
+        scheduleTime = playbackTime - scheduleAdvanceSec;
         const minScheduleTimeSec = this.recorrectionMonitor.minScheduleTimeSec;
         if (minScheduleTimeSec !== null) {
           // After a cutover, drop backlog that ends at or before the kept tail
@@ -881,7 +893,7 @@ export class AudioScheduler {
             continue;
           }
           scheduleTime = Math.max(scheduleTime, minScheduleTimeSec);
-          playbackTime = scheduleTime + syncDelaySec;
+          playbackTime = scheduleTime + scheduleAdvanceSec;
         }
         this.recorrectionMonitor.clearMinScheduleTime();
         playbackRate = 1.0;
@@ -907,9 +919,9 @@ export class AudioScheduler {
             this.resyncCount++;
             this._intervalResyncCount++;
             this.resetSyncErrorEma();
-            this.cutScheduledSources(targetPlaybackTime - syncDelaySec);
+            this.cutScheduledSources(targetPlaybackTime - scheduleAdvanceSec);
             playbackTime = targetPlaybackTime;
-            scheduleTime = playbackTime - syncDelaySec;
+            scheduleTime = playbackTime - scheduleAdvanceSec;
             playbackRate = 1.0;
             this.currentCorrectionMethod = "resync";
             this.lastSamplesAdjusted = 0;
@@ -970,10 +982,10 @@ export class AudioScheduler {
             this.recorrectionMonitor.noteHardResync(nowMs);
             this.resyncCount++;
             this._intervalResyncCount++;
-            this.cutScheduledSources(targetPlaybackTime - syncDelaySec);
+            this.cutScheduledSources(targetPlaybackTime - scheduleAdvanceSec);
           }
           playbackTime = targetPlaybackTime;
-          scheduleTime = playbackTime - syncDelaySec;
+          scheduleTime = playbackTime - scheduleAdvanceSec;
           playbackRate = 1.0;
           this.currentCorrectionMethod = "resync";
           this.lastSamplesAdjusted = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -453,9 +453,9 @@ export interface SendspinPlayerConfig extends SendspinCoreConfig {
   >;
 
   /**
-   * Use browser's output latency API for automatic latency compensation.
-   * When enabled, reads AudioContext.baseLatency and outputLatency to
-   * compensate for hardware delay (e.g., Bluetooth headphones).
+   * Use automatic output latency compensation.
+   * When enabled, reads AudioContext.baseLatency and outputLatency and applies
+   * platform fallbacks where those APIs underreport the output path.
    *
    * Note: API reliability varies by browser/platform. But generally works well,
    * especially on modern mobile browsers.

--- a/tests/unit/platform-output-latency.test.ts
+++ b/tests/unit/platform-output-latency.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getUnreportedOutputLatencyMs } from "../../src/audio/platform-output-latency";
+
+const MAC_SAFARI =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15";
+const MAC_CHROME =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36";
+const MAC_FIREFOX =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:141.0) Gecko/20100101 Firefox/141.0";
+const IPHONE_SAFARI =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1";
+const IPHONE_CHROME =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/140.0.0.0 Mobile/15E148 Safari/604.1";
+const ANDROID_CHROME =
+  "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36";
+
+describe("getUnreportedOutputLatencyMs", () => {
+  it.each([
+    ["macOS Safari", MAC_SAFARI, {}, 100],
+    ["macOS Chrome", MAC_CHROME, {}, 0],
+    ["macOS Firefox", MAC_FIREFOX, {}, 0],
+    ["iPhone Safari", IPHONE_SAFARI, {}, 100],
+    ["iPhone Chrome", IPHONE_CHROME, {}, 100],
+    ["Android Chrome", ANDROID_CHROME, {}, 0],
+    [
+      "iPad desktop mode",
+      MAC_SAFARI,
+      { platform: "MacIntel", maxTouchPoints: 5 },
+      100,
+    ],
+  ])(
+    "%s uses the expected compensation",
+    (_name, userAgent, extra, expected) => {
+      expect(getUnreportedOutputLatencyMs({ userAgent, ...extra })).toBe(
+        expected,
+      );
+    },
+  );
+
+  it("returns 0 outside a browser", () => {
+    expect(getUnreportedOutputLatencyMs(undefined)).toBe(0);
+  });
+});

--- a/tests/unit/scheduler.test.ts
+++ b/tests/unit/scheduler.test.ts
@@ -366,6 +366,39 @@ describe("AudioScheduler scheduling math", () => {
     );
   });
 
+  it("compensates Apple WebKit without changing the user sync delay", () => {
+    vi.stubGlobal("navigator", {
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15",
+    });
+    const { scheduler, ctx } = setup({
+      useOutputLatencyCompensation: true,
+    });
+    scheduler.handleDecodedChunk(makeChunk(nowUs() + 1_000_000, 0));
+    scheduler.processAudioQueue();
+
+    expect(scheduler.getSyncDelayMs()).toBe(0);
+    expect(scheduler.syncInfo.outputLatencyMs).toBe(100);
+    expect(ctx.startedSources[0].started!).toBeCloseTo(
+      ctx.currentTime + 0.9,
+      6,
+    );
+  });
+
+  it("does not apply the WebKit correction when latency compensation is disabled", () => {
+    vi.stubGlobal("navigator", {
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1",
+    });
+    const { scheduler, ctx } = setup({
+      useOutputLatencyCompensation: false,
+    });
+    scheduler.handleDecodedChunk(makeChunk(nowUs() + 1_000_000, 0));
+    scheduler.processAudioQueue();
+
+    expect(ctx.startedSources[0].started!).toBeCloseTo(ctx.currentTime + 1, 6);
+  });
+
   it("future-timestamped chunk schedules later by the client-time delta", () => {
     const { scheduler, ctx } = setup();
     // 2 seconds in the future (server clock)


### PR DESCRIPTION
Safari and iOS WebKit underreport output latency, leaving playback roughly 100 ms behind other players even with static delay set to 0. Apply an internal platform fallback while keeping user-configured static delay separate and preserving the latency-compensation opt-out.

After this PR the correct default delay on all platforms is 0ms.

Fixes a regression from:
- #159